### PR TITLE
feat(pr): add AI-powered PR creation with interactive TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ gelf is a Go-based CLI tool that automatically generates Git commit messages and
 
 - 🤖 **AI-Powered**: Intelligent commit message generation using Vertex AI (Gemini)
 - 🔍 **Code Review**: AI-powered code review with streaming real-time feedback
+- 📝 **PR Creation**: Generate pull request titles and descriptions with AI
 - 🎨 **Clean TUI**: Simple and intuitive user interface built with Bubble Tea  
 - ⚡ **Fast Processing**: Real-time progress indicators and streaming responses
 - 🛡️ **Safe Operations**: Only operates on staged changes for secure workflow
@@ -72,6 +73,10 @@ commit:
   language: "english"  # optional, inherits from global language
 
 review:
+  model: "pro"       # optional, default: pro
+  language: "english"  # optional, inherits from global language
+
+pr:
   model: "pro"       # optional, default: pro
   language: "english"  # optional, inherits from global language
 
@@ -146,6 +151,20 @@ The review feature provides:
    - Performance and maintainability suggestions
    - No interactive prompts - displays results directly
 
+### Pull Request Creation
+
+Generate pull requests with AI-generated titles and descriptions based on committed changes:
+
+```bash
+gelf pr create
+```
+
+Options:
+- `--draft` to create a draft PR
+- `--dry-run` to print the generated title/body without creating a PR
+- `--model` to override the model for PR generation
+- `--language` to set the output language
+
 ### Documentation Generation
 
 Generate AI-powered documentation for your codebase:
@@ -219,6 +238,18 @@ gelf review --no-style
 # Generate code review in a specific language
 gelf review --language japanese
 
+# Create a pull request with AI-generated title/body
+gelf pr create
+
+# Create a draft pull request
+gelf pr create --draft
+
+# Preview generated PR title/body without creating a PR
+gelf pr create --dry-run
+
+# Use specific model and language for PR generation
+gelf pr create --model gemini-2.0-flash-exp --language japanese
+
 # Generate documentation
 gelf doc --src . --dst README.md --template readme
 
@@ -255,6 +286,7 @@ While gelf can work with any language supported by Gemini models, common example
 # Set language for specific commands
 gelf commit --language japanese
 gelf review --language spanish
+gelf pr create --language french
 gelf doc --src . --dst README.md --template readme --language french
 
 # Use different languages for different operations
@@ -273,6 +305,9 @@ commit:
 review:
   language: "english"   # Language for code reviews
 
+pr:
+  language: "english"   # Language for pull request titles and descriptions
+
 doc:
   language: "english"   # Language for documentation generation
 ```
@@ -282,7 +317,7 @@ If no language is specified, commit, review, and documentation generation will u
 
 ### Priority Order
 1. Command-line `--language` flag (highest priority)
-2. Configuration file command-specific settings (`commit.language`/`review.language`/`doc.language`)
+2. Configuration file command-specific settings (`commit.language`/`review.language`/`pr.language`/`doc.language`)
 3. Configuration file global setting (`language`)
 4. Default value (`english`)
 
@@ -308,10 +343,14 @@ cmd/
 ├── root.go          # Root command definition
 ├── commit.go        # Commit command implementation
 ├── review.go        # Review command implementation
+├── pr.go            # Pull request command implementation
 └── doc.go           # Documentation generation command implementation
 internal/
 ├── git/
-│   └── diff.go      # Git operations (staged and unstaged diffs)
+│   ├── diff.go      # Git operations (staged and unstaged diffs)
+│   └── branch.go    # Branch and commit range helpers
+├── github/
+│   └── template.go  # GitHub PR template resolution
 ├── ai/
 │   └── vertex.go    # Vertex AI integration (commit messages, code review, and documentation)
 ├── ui/
@@ -373,6 +412,10 @@ commit:
 review:
   model: string          # Model for reviews: "flash", "pro", or custom (default: pro)
   language: string       # Language for code reviews (inherits from global if not set)
+
+pr:
+  model: string          # Model for pull requests: "flash", "pro", or custom (default: pro)
+  language: string       # Language for pull request titles and descriptions (inherits from global if not set)
 
 doc:
   model: string          # Model for documentation: "flash", "pro", or custom (default: pro)

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ gelf pr create
 Options:
 - `--draft` to create a draft PR
 - `--dry-run` to print the generated title/body without creating a PR
+- `--render` to render markdown in dry-run output (default: true)
+- `--no-render` to disable markdown rendering in dry-run output
 - `--model` to override the model for PR generation
 - `--language` to set the output language
 
@@ -246,6 +248,9 @@ gelf pr create --draft
 
 # Preview generated PR title/body without creating a PR
 gelf pr create --dry-run
+
+# Preview without markdown rendering
+gelf pr create --dry-run --no-render
 
 # Use specific model and language for PR generation
 gelf pr create --model gemini-2.0-flash-exp --language japanese

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Options:
 - `--no-render` to disable markdown rendering in dry-run output
 - `--model` to override the model for PR generation
 - `--language` to set the output language
+- `--yes` to skip confirmation prompt
 
 ### Documentation Generation
 
@@ -254,6 +255,9 @@ gelf pr create --dry-run --no-render
 
 # Use specific model and language for PR generation
 gelf pr create --model gemini-2.0-flash-exp --language japanese
+
+# Skip confirmation prompt
+gelf pr create --yes
 
 # Generate documentation
 gelf doc --src . --dst README.md --template readme

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/EkeMinusYou/gelf/internal/config"
+	"github.com/spf13/cobra"
 )
 
 var configCmd = &cobra.Command{
@@ -42,6 +42,8 @@ func runConfigList(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Commit Language:   %s\n", cfg.CommitLanguage)
 	fmt.Printf("Review Model:      %s\n", cfg.ReviewModel)
 	fmt.Printf("Review Language:   %s\n", cfg.ReviewLanguage)
+	fmt.Printf("PR Model:          %s\n", cfg.PRModel)
+	fmt.Printf("PR Language:       %s\n", cfg.PRLanguage)
 
 	fmt.Println("\nEnvironment Variables:")
 	fmt.Println("======================")

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -10,6 +10,7 @@ import (
 	"github.com/EkeMinusYou/gelf/internal/config"
 	"github.com/EkeMinusYou/gelf/internal/git"
 	"github.com/EkeMinusYou/gelf/internal/github"
+	"github.com/charmbracelet/glamour"
 	"github.com/spf13/cobra"
 )
 
@@ -143,7 +144,14 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "Base: %s\nHead: %s\n\n", baseBranch, headBranch)
 		fmt.Fprintf(cmd.OutOrStdout(), "Title:\n%s\n\n", prContent.Title)
-		fmt.Fprintf(cmd.OutOrStdout(), "Body:\n%s\n", prContent.Body)
+		fmt.Fprintf(cmd.OutOrStdout(), "Body (rendered):\n")
+		rendered, err := renderMarkdown(prContent.Body)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Failed to render markdown: %v\n", err)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", prContent.Body)
+			return nil
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", rendered)
 		return nil
 	}
 
@@ -161,4 +169,16 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func renderMarkdown(markdown string) (string, error) {
+	renderer, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(0),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return renderer.Render(markdown)
 }

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -201,7 +201,6 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if !confirmed {
-			fmt.Fprintln(cmd.OutOrStdout(), "Cancelled.")
 			return nil
 		}
 		prContent = content

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -150,10 +150,9 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 		if templateContent != "" {
 			fmt.Fprintf(cmd.ErrOrStderr(), "Using %s template: %s\n", templateSource, templatePath)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Base: %s\nHead: %s\n\n", baseBranch, headBranch)
 		fmt.Fprintf(cmd.OutOrStdout(), "Title:\n%s\n\n", prContent.Title)
 		if prRender {
-			fmt.Fprintf(cmd.OutOrStdout(), "Body (rendered):\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "Body:\n")
 			rendered, err := renderMarkdown(prContent.Body)
 			if err != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "Failed to render markdown: %v\n", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,7 @@ func init() {
 	rootCmd.AddCommand(commitCmd)
 	rootCmd.AddCommand(reviewCmd)
 	rootCmd.AddCommand(docCmd)
+	rootCmd.AddCommand(prCmd)
 	rootCmd.AddCommand(versionCmd)
 
 	// Add completion commands

--- a/gelf.yml.example
+++ b/gelf.yml.example
@@ -41,6 +41,14 @@ review:
   # Language for code reviews (optional, inherits from global language if not set)
   language: "english"
 
+# PR-specific settings
+pr:
+  # Model to use for pull requests: "flash", "pro", or custom model name (default: pro)
+  model: "pro"
+
+  # Language for pull request titles and descriptions (optional, inherits from global language if not set)
+  language: "english"
+
 # Configuration priority (highest to lowest):
 # 1. Environment variables (VERTEXAI_PROJECT, VERTEXAI_LOCATION)
 # 2. This configuration file

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,10 +12,14 @@ type Config struct {
 	Location       string
 	FlashModel     string
 	ProModel       string
+	BaseFlashModel string
+	BaseProModel   string
 	CommitLanguage string
 	ReviewLanguage string
 	CommitModel    string
 	ReviewModel    string
+	PRLanguage     string
+	PRModel        string
 	Color          string
 }
 
@@ -38,6 +42,10 @@ type FileConfig struct {
 		Model    string `yaml:"model"`
 		Language string `yaml:"language"`
 	} `yaml:"review"`
+	PR struct {
+		Model    string `yaml:"model"`
+		Language string `yaml:"language"`
+	} `yaml:"pr"`
 }
 
 func Load() (*Config, error) {
@@ -104,6 +112,17 @@ func Load() (*Config, error) {
 		reviewLanguage = defaultLanguage
 	}
 
+	// PR settings
+	prModel := fileConfig.PR.Model
+	if prModel == "" {
+		prModel = "pro" // default to pro model
+	}
+
+	prLanguage := fileConfig.PR.Language
+	if prLanguage == "" {
+		prLanguage = defaultLanguage
+	}
+
 	// Color settings
 	color := fileConfig.Color
 	if color == "" {
@@ -135,10 +154,14 @@ func Load() (*Config, error) {
 		Location:       location,
 		FlashModel:     actualFlashModel,
 		ProModel:       actualProModel,
+		BaseFlashModel: flashModel,
+		BaseProModel:   proModel,
 		CommitLanguage: commitLanguage,
 		ReviewLanguage: reviewLanguage,
 		CommitModel:    commitModel,
 		ReviewModel:    reviewModel,
+		PRLanguage:     prLanguage,
+		PRModel:        prModel,
 		Color:          color,
 	}, nil
 }
@@ -196,5 +219,22 @@ func (c *Config) UseColor() bool {
 		return true
 	default:
 		return true
+	}
+}
+
+func (c *Config) ResolveModel(name string) string {
+	switch name {
+	case "", "flash":
+		if c.BaseFlashModel != "" {
+			return c.BaseFlashModel
+		}
+		return c.FlashModel
+	case "pro":
+		if c.BaseProModel != "" {
+			return c.BaseProModel
+		}
+		return c.ProModel
+	default:
+		return name
 	}
 }

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -1,0 +1,128 @@
+package git
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func GetRepoRoot() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get repository root: %w", err)
+	}
+
+	root := strings.TrimSpace(string(output))
+	if root == "" {
+		return "", fmt.Errorf("repository root is empty")
+	}
+
+	return root, nil
+}
+
+func GetCurrentBranch() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current branch: %w", err)
+	}
+
+	branch := strings.TrimSpace(string(output))
+	if branch == "" {
+		return "", fmt.Errorf("current branch is empty")
+	}
+
+	return branch, nil
+}
+
+func GetDefaultBaseBranch() (string, error) {
+	if branch, err := originHeadBranch(); err == nil && branch != "" {
+		return branch, nil
+	}
+
+	branch, err := remoteShowHeadBranch()
+	if err != nil {
+		return "", err
+	}
+
+	if branch == "" {
+		return "", fmt.Errorf("failed to determine base branch")
+	}
+
+	return branch, nil
+}
+
+func originHeadBranch() (string, error) {
+	cmd := exec.Command("git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	ref := strings.TrimSpace(string(output))
+	if ref == "" {
+		return "", fmt.Errorf("origin/HEAD is empty")
+	}
+
+	if strings.HasPrefix(ref, "origin/") {
+		return strings.TrimPrefix(ref, "origin/"), nil
+	}
+
+	return "", fmt.Errorf("unexpected origin/HEAD ref: %s", ref)
+}
+
+func remoteShowHeadBranch() (string, error) {
+	cmd := exec.Command("git", "remote", "show", "origin")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect origin remote: %w", err)
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	const prefix = "HEAD branch: "
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(line, prefix)), nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	return "", fmt.Errorf("HEAD branch not found in origin remote info")
+}
+
+func GetCommittedDiff(baseRef, headRef string) (string, error) {
+	cmd := exec.Command("git", "--no-pager", "diff", "-U5", fmt.Sprintf("%s...%s", baseRef, headRef))
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}
+
+func GetCommittedDiffStat(baseRef, headRef string) (string, error) {
+	cmd := exec.Command("git", "--no-pager", "diff", "--stat", fmt.Sprintf("%s...%s", baseRef, headRef))
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}
+
+func GetCommitLog(baseRef, headRef string) (string, error) {
+	rangeSpec := fmt.Sprintf("%s..%s", baseRef, headRef)
+	cmd := exec.Command("git", "log", "--reverse", "--format=%h %s", rangeSpec)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}

--- a/internal/git/push.go
+++ b/internal/git/push.go
@@ -1,0 +1,112 @@
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type PushStatus struct {
+	HasUpstream bool
+	UpstreamRef string
+	RemoteName  string
+	RemoteRef   string
+	HeadPushed  bool
+}
+
+func GetPushStatus(branch string) (PushStatus, error) {
+	status := PushStatus{}
+
+	upstreamRef, hasUpstream, err := getUpstreamRef()
+	if err != nil {
+		return status, err
+	}
+
+	if hasUpstream {
+		status.HasUpstream = true
+		status.UpstreamRef = upstreamRef
+		status.RemoteRef = upstreamRef
+		status.RemoteName = remoteNameFromRef(upstreamRef)
+		pushed, err := isAncestor("HEAD", upstreamRef)
+		if err != nil {
+			return status, err
+		}
+		status.HeadPushed = pushed
+		return status, nil
+	}
+
+	status.RemoteName = "origin"
+	status.RemoteRef = fmt.Sprintf("origin/%s", branch)
+
+	exists, err := remoteBranchExists(status.RemoteRef)
+	if err != nil {
+		return status, err
+	}
+	if !exists {
+		return status, nil
+	}
+
+	pushed, err := isAncestor("HEAD", status.RemoteRef)
+	if err != nil {
+		return status, err
+	}
+	status.HeadPushed = pushed
+	return status, nil
+}
+
+func getUpstreamRef() (string, bool, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if exitErr.ExitCode() == 128 {
+				return "", false, nil
+			}
+		}
+		return "", false, fmt.Errorf("failed to determine upstream branch: %w", err)
+	}
+
+	ref := strings.TrimSpace(string(output))
+	if ref == "" {
+		return "", false, nil
+	}
+
+	return ref, true, nil
+}
+
+func isAncestor(ancestorRef, descendantRef string) (bool, error) {
+	cmd := exec.Command("git", "merge-base", "--is-ancestor", ancestorRef, descendantRef)
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if exitErr.ExitCode() == 1 {
+				return false, nil
+			}
+		}
+		return false, fmt.Errorf("failed to compare git refs: %w", err)
+	}
+
+	return true, nil
+}
+
+func remoteBranchExists(remoteRef string) (bool, error) {
+	ref := fmt.Sprintf("refs/remotes/%s", remoteRef)
+	cmd := exec.Command("git", "show-ref", "--verify", "--quiet", ref)
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if exitErr.ExitCode() == 1 {
+				return false, nil
+			}
+		}
+		return false, fmt.Errorf("failed to check remote branch: %w", err)
+	}
+
+	return true, nil
+}
+
+func remoteNameFromRef(ref string) string {
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return "origin"
+	}
+	return parts[0]
+}

--- a/internal/github/gh.go
+++ b/internal/github/gh.go
@@ -1,0 +1,57 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type RepoInfo struct {
+	Owner string
+	Name  string
+}
+
+func AuthToken(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", "auth", "token")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get GitHub auth token: %w", err)
+	}
+
+	token := strings.TrimSpace(string(output))
+	if token == "" {
+		return "", fmt.Errorf("gh auth token returned empty output")
+	}
+
+	return token, nil
+}
+
+func RepoInfoFromGH(ctx context.Context) (*RepoInfo, error) {
+	cmd := exec.CommandContext(ctx, "gh", "repo", "view", "--json", "owner,name")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repository info: %w", err)
+	}
+
+	var result struct {
+		Owner struct {
+			Login string `json:"login"`
+		} `json:"owner"`
+		Name string `json:"name"`
+	}
+
+	if err := json.Unmarshal(output, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse repository info: %w", err)
+	}
+
+	if result.Owner.Login == "" || result.Name == "" {
+		return nil, fmt.Errorf("repository info is incomplete")
+	}
+
+	return &RepoInfo{
+		Owner: result.Owner.Login,
+		Name:  result.Name,
+	}, nil
+}

--- a/internal/github/template.go
+++ b/internal/github/template.go
@@ -1,0 +1,318 @@
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type PullRequestTemplate struct {
+	Source  string
+	Path    string
+	Content string
+}
+
+var templateFileCandidates = []string{
+	".github/PULL_REQUEST_TEMPLATE.md",
+	".github/pull_request_template.md",
+	"PULL_REQUEST_TEMPLATE.md",
+	"pull_request_template.md",
+	"docs/PULL_REQUEST_TEMPLATE.md",
+	"docs/pull_request_template.md",
+}
+
+var templateDirCandidates = []string{
+	".github/PULL_REQUEST_TEMPLATE",
+	".github/pull_request_template",
+	"PULL_REQUEST_TEMPLATE",
+	"pull_request_template",
+	"docs/PULL_REQUEST_TEMPLATE",
+	"docs/pull_request_template",
+}
+
+func FindPullRequestTemplate(ctx context.Context, repoRoot, token, owner string) (*PullRequestTemplate, error) {
+	localTemplate, err := findLocalPullRequestTemplate(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	if localTemplate != nil {
+		return localTemplate, nil
+	}
+
+	if owner == "" || token == "" {
+		return nil, nil
+	}
+
+	return findOrgPullRequestTemplate(ctx, token, owner)
+}
+
+func findLocalPullRequestTemplate(repoRoot string) (*PullRequestTemplate, error) {
+	for _, relPath := range templateFileCandidates {
+		path := filepath.Join(repoRoot, relPath)
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			continue
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read template file %s: %w", relPath, err)
+		}
+
+		return &PullRequestTemplate{
+			Source:  "repo",
+			Path:    relPath,
+			Content: string(content),
+		}, nil
+	}
+
+	for _, relDir := range templateDirCandidates {
+		dirPath := filepath.Join(repoRoot, relDir)
+		info, err := os.Stat(dirPath)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+
+		selected, content, err := selectTemplateFromDir(dirPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read template directory %s: %w", relDir, err)
+		}
+		if selected == "" {
+			continue
+		}
+
+		return &PullRequestTemplate{
+			Source:  "repo",
+			Path:    filepath.ToSlash(filepath.Join(relDir, selected)),
+			Content: content,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func selectTemplateFromDir(dirPath string) (string, string, error) {
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return "", "", err
+	}
+
+	var candidates []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if isTemplateFile(name) {
+			candidates = append(candidates, name)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return "", "", nil
+	}
+
+	sort.Strings(candidates)
+	selected := candidates[0]
+	content, err := os.ReadFile(filepath.Join(dirPath, selected))
+	if err != nil {
+		return "", "", err
+	}
+
+	return selected, string(content), nil
+}
+
+func isTemplateFile(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.HasSuffix(lower, ".md") || strings.HasSuffix(lower, ".markdown") || strings.HasSuffix(lower, ".txt")
+}
+
+func findOrgPullRequestTemplate(ctx context.Context, token, owner string) (*PullRequestTemplate, error) {
+	orgRepo := ".github"
+
+	for _, relPath := range templateFileCandidates {
+		content, found, err := fetchGitHubFile(ctx, token, owner, orgRepo, relPath)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			return &PullRequestTemplate{
+				Source:  "org",
+				Path:    relPath,
+				Content: content,
+			}, nil
+		}
+	}
+
+	for _, relDir := range templateDirCandidates {
+		selected, err := fetchGitHubDirTemplate(ctx, token, owner, orgRepo, relDir)
+		if err != nil {
+			return nil, err
+		}
+		if selected == nil {
+			continue
+		}
+
+		return &PullRequestTemplate{
+			Source:  "org",
+			Path:    selected.Path,
+			Content: selected.Content,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+type dirTemplate struct {
+	Path    string
+	Content string
+}
+
+func fetchGitHubDirTemplate(ctx context.Context, token, owner, repo, dirPath string) (*dirTemplate, error) {
+	entries, found, err := fetchGitHubDir(ctx, token, owner, repo, dirPath)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+
+	var candidates []string
+	for _, entry := range entries {
+		if entry.Type != "file" {
+			continue
+		}
+		if isTemplateFile(entry.Name) {
+			candidates = append(candidates, entry.Path)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	sort.Strings(candidates)
+	selectedPath := candidates[0]
+	content, found, err := fetchGitHubFile(ctx, token, owner, repo, selectedPath)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+
+	return &dirTemplate{
+		Path:    selectedPath,
+		Content: content,
+	}, nil
+}
+
+type githubDirEntry struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+	Type string `json:"type"`
+}
+
+func fetchGitHubDir(ctx context.Context, token, owner, repo, path string) ([]githubDirEntry, bool, error) {
+	body, status, err := fetchGitHubContent(ctx, token, owner, repo, path)
+	if err != nil {
+		return nil, false, err
+	}
+	if status == http.StatusNotFound {
+		return nil, false, nil
+	}
+	if status != http.StatusOK {
+		return nil, false, fmt.Errorf("unexpected status %d when fetching directory %s", status, path)
+	}
+
+	var entries []githubDirEntry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return nil, false, fmt.Errorf("failed to parse directory listing for %s: %w", path, err)
+	}
+
+	return entries, true, nil
+}
+
+func fetchGitHubFile(ctx context.Context, token, owner, repo, path string) (string, bool, error) {
+	body, status, err := fetchGitHubContent(ctx, token, owner, repo, path)
+	if err != nil {
+		return "", false, err
+	}
+	if status == http.StatusNotFound {
+		return "", false, nil
+	}
+	if status != http.StatusOK {
+		return "", false, fmt.Errorf("unexpected status %d when fetching file %s", status, path)
+	}
+
+	var file struct {
+		Type     string `json:"type"`
+		Encoding string `json:"encoding"`
+		Content  string `json:"content"`
+	}
+
+	if err := json.Unmarshal(body, &file); err != nil {
+		return "", false, fmt.Errorf("failed to parse file response for %s: %w", path, err)
+	}
+
+	if file.Type != "file" {
+		return "", false, nil
+	}
+
+	content := file.Content
+	if file.Encoding == "base64" {
+		decoded, err := decodeBase64(content)
+		if err != nil {
+			return "", false, fmt.Errorf("failed to decode base64 content for %s: %w", path, err)
+		}
+		content = decoded
+	}
+
+	return content, true, nil
+}
+
+func fetchGitHubContent(ctx context.Context, token, owner, repo, path string) ([]byte, int, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s", owner, repo, path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "gelf")
+	if token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+
+	return body, resp.StatusCode, nil
+}
+
+func decodeBase64(encoded string) (string, error) {
+	cleaned := strings.ReplaceAll(encoded, "\n", "")
+	decoded, err := base64.StdEncoding.DecodeString(cleaned)
+	if err != nil {
+		return "", err
+	}
+	return string(decoded), nil
+}

--- a/internal/ui/markdown.go
+++ b/internal/ui/markdown.go
@@ -1,0 +1,22 @@
+package ui
+
+import "github.com/charmbracelet/glamour"
+
+func RenderMarkdown(markdown string, useColor bool) (string, error) {
+	opts := []glamour.TermRendererOption{
+		glamour.WithWordWrap(0),
+	}
+
+	if useColor {
+		opts = append(opts, glamour.WithAutoStyle())
+	} else {
+		opts = append(opts, glamour.WithStandardStyle("ascii"))
+	}
+
+	renderer, err := glamour.NewTermRenderer(opts...)
+	if err != nil {
+		return "", err
+	}
+
+	return renderer.Render(markdown)
+}

--- a/internal/ui/pr.go
+++ b/internal/ui/pr.go
@@ -117,7 +117,7 @@ func (m *prModel) View() string {
 	case prStateLoading:
 		loadingText := fmt.Sprintf("%s %s",
 			m.spinner.View(),
-			loadingStyle.Render("Generating pull request..."))
+			loadingStyle.Render("Generating pull request message..."))
 
 		return fmt.Sprintf("%s\n\n%s", formatPRContext(m.diffSummary, m.commitLines), loadingText)
 

--- a/internal/ui/pr.go
+++ b/internal/ui/pr.go
@@ -1,0 +1,214 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/EkeMinusYou/gelf/internal/ai"
+	"github.com/EkeMinusYou/gelf/internal/git"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type prState int
+
+const (
+	prStateLoading prState = iota
+	prStateConfirm
+	prStateDone
+	prStateError
+)
+
+type prModel struct {
+	aiClient     *ai.VertexAIClient
+	input        ai.PullRequestInput
+	diffSummary  git.DiffSummary
+	render       bool
+	useColor     bool
+	renderedBody string
+	content      *ai.PullRequestContent
+	confirmed    bool
+	err          error
+	state        prState
+	spinner      spinner.Model
+}
+
+type msgPRGenerated struct {
+	content      *ai.PullRequestContent
+	renderedBody string
+	err          error
+}
+
+func NewPRTUI(aiClient *ai.VertexAIClient, input ai.PullRequestInput, render bool, useColor bool) *prModel {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = loadingStyle
+
+	diffSummary := git.ParseDiffSummary(input.Diff)
+
+	return &prModel{
+		aiClient:    aiClient,
+		input:       input,
+		diffSummary: diffSummary,
+		render:      render,
+		useColor:    useColor,
+		state:       prStateLoading,
+		spinner:     s,
+	}
+}
+
+func (m *prModel) Init() tea.Cmd {
+	return tea.Batch(m.spinner.Tick, m.generatePRContent())
+}
+
+func (m *prModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch m.state {
+		case prStateLoading:
+			switch msg.String() {
+			case "q", "ctrl+c":
+				m.state = prStateDone
+				return m, tea.Quit
+			}
+		case prStateConfirm:
+			switch msg.String() {
+			case "y", "Y":
+				m.confirmed = true
+				m.state = prStateDone
+				return m, tea.Quit
+			case "n", "N", "q", "ctrl+c":
+				m.confirmed = false
+				m.state = prStateDone
+				return m, tea.Quit
+			}
+		case prStateDone, prStateError:
+			return m, tea.Quit
+		}
+
+	case msgPRGenerated:
+		if msg.err != nil {
+			m.err = msg.err
+			m.state = prStateError
+		} else {
+			m.content = msg.content
+			m.renderedBody = msg.renderedBody
+			m.state = prStateConfirm
+		}
+		return m, nil
+	}
+
+	if m.state == prStateLoading {
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m *prModel) View() string {
+	switch m.state {
+	case prStateLoading:
+		loadingText := fmt.Sprintf("%s %s",
+			m.spinner.View(),
+			loadingStyle.Render("Generating pull request..."))
+
+		diffSummary := formatPRDiffSummary(m.diffSummary)
+		if diffSummary != "" {
+			return fmt.Sprintf("%s\n\n%s", diffSummary, loadingText)
+		}
+		return loadingText
+
+	case prStateConfirm:
+		header := titleStyle.Render("📝 Generated Pull Request:")
+		title := messageStyle.Render(m.content.Title)
+		body := m.content.Body
+		if m.render && m.renderedBody != "" {
+			body = m.renderedBody
+		}
+
+		prompt := promptStyle.Render("Create this pull request? (y)es / (n)o")
+		diffSummary := formatPRDiffSummary(m.diffSummary)
+		if diffSummary != "" {
+			return fmt.Sprintf("%s\n\n%s\n\n%s\n\n%s\n\n%s", diffSummary, header, title, body, prompt)
+		}
+		return fmt.Sprintf("%s\n\n%s\n\n%s\n\n%s", header, title, body, prompt)
+
+	case prStateError:
+		return errorStyle.Render(fmt.Sprintf("✗ Error: %v", m.err))
+
+	case prStateDone:
+		return ""
+	}
+
+	return ""
+}
+
+func (m *prModel) Run() (*ai.PullRequestContent, bool, error) {
+	p := tea.NewProgram(m)
+	_, err := p.Run()
+	if err != nil {
+		return nil, false, err
+	}
+
+	if m.err != nil {
+		return nil, false, m.err
+	}
+
+	return m.content, m.confirmed, nil
+}
+
+func (m *prModel) generatePRContent() tea.Cmd {
+	return tea.Cmd(func() tea.Msg {
+		ctx := context.Background()
+		content, err := m.aiClient.GeneratePullRequestContent(ctx, m.input)
+		if err != nil {
+			return msgPRGenerated{err: err}
+		}
+
+		rendered := ""
+		if m.render {
+			rendered, err = RenderMarkdown(content.Body, m.useColor)
+			if err != nil {
+				rendered = ""
+			}
+		}
+
+		return msgPRGenerated{
+			content:      content,
+			renderedBody: strings.TrimRight(rendered, "\n"),
+		}
+	})
+}
+
+func formatPRDiffSummary(summary git.DiffSummary) string {
+	if len(summary.Files) == 0 {
+		return ""
+	}
+
+	var parts []string
+	parts = append(parts, diffStyle.Render("📄 Changed Files:"))
+
+	for _, file := range summary.Files {
+		fileName := fileStyle.Render(file.Name)
+
+		var changes []string
+		if file.AddedLines > 0 {
+			changes = append(changes, addedStyle.Render(fmt.Sprintf("+%d", file.AddedLines)))
+		}
+		if file.DeletedLines > 0 {
+			changes = append(changes, deletedStyle.Render(fmt.Sprintf("-%d", file.DeletedLines)))
+		}
+
+		if len(changes) > 0 {
+			parts = append(parts, fmt.Sprintf(" • %s (%s)", fileName, strings.Join(changes, ", ")))
+		} else {
+			parts = append(parts, fmt.Sprintf(" • %s", fileName))
+		}
+	}
+
+	return strings.Join(parts, "\n")
+}

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -1,0 +1,63 @@
+package ui
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+func PromptYesNoStyled(prompt string) (bool, error) {
+	return PromptYesNo(promptStyle.Render(prompt))
+}
+
+func PromptYesNo(prompt string) (bool, error) {
+	fmt.Printf("%s ", prompt)
+
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+		if err == nil {
+			defer func() {
+				_ = term.Restore(int(os.Stdin.Fd()), oldState)
+			}()
+
+			reader := bufio.NewReader(os.Stdin)
+			for {
+				b, err := reader.ReadByte()
+				if err != nil {
+					return false, err
+				}
+
+				switch b {
+				case '\r', '\n':
+					continue
+				}
+
+				ch := strings.ToLower(string(b))
+				if ch == "y" {
+					fmt.Println()
+					return true, nil
+				}
+				if ch == "n" {
+					fmt.Println()
+					return false, nil
+				}
+			}
+		}
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+
+	line = strings.TrimSpace(line)
+	if strings.HasPrefix(strings.ToLower(line), "y") {
+		return true, nil
+	}
+	return false, nil
+}


### PR DESCRIPTION
### Summary

This pull request introduces a major new feature: `gelf pr create`. This command leverages AI to automatically generate a pull request title and description based on the commits and diff between the current branch and the repository's default base branch.

To ensure a high-quality user experience, the feature includes an interactive TUI that displays the generated content for review, allowing the user to confirm or cancel before the PR is created on GitHub. It also intelligently handles pre-flight checks, such as prompting the user to push their branch if it's not yet on the remote.

### Changes

- **New Command `gelf pr create`**:
  - Added a new top-level `pr` command with a `create` subcommand.
  - Supports flags for customization:
    - `--draft`: Create a draft pull request.
    - `--dry-run`: Print the generated title/body to the console without creating a PR.
    - `--render` / `--no-render`: Control markdown rendering in dry-run mode.
    - `--yes`: Skip the interactive TUI and create the PR directly.
    - `--model`, `--language`: Override AI model and language settings.

- **AI Integration**:
  - Implemented `GeneratePullRequestContent` in `internal/ai/vertex.go` to generate the PR title and body.
  - The AI prompt includes the base/head branches, commit log, diff stat, and the full diff to provide comprehensive context.

- **Interactive TUI (`internal/ui/pr.go`)**:
  - A new TUI built with Bubble Tea provides an interactive flow for PR creation.
  - Displays a loading spinner while the AI generates content.
  - Shows contextual information (changed files, commit list) before presenting the result.
  - Includes a scrollable viewport (`internal/ui/pr.go`) to review long PR descriptions.
  - Uses a simple, single-key press (`y`/`n`) for confirmation prompts (`internal/ui/prompt.go`).

- **Git & GitHub Integration**:
  - **Branch & Diff Logic (`internal/git/`)**: Added helpers to determine the default base branch, get the commit log, and calculate the diff between the head and base.
  - **Push Check (`internal/git/push.go`)**: Before creating a PR, the tool now checks if the current branch is pushed to the remote and prompts the user to push if it isn't.
  - **PR Template Discovery (`internal/github/template.go`)**: Implemented robust logic to find `PULL_REQUEST_TEMPLATE.md` files, supporting standard locations within the repository and in the organization's `.github` repository.

- **Configuration (`internal/config/config.go`)**:
  - Added a `pr` section to `gelf.yml` to allow users to configure a default model and language for PR generation.

- **Documentation**:
  - Updated `README.md` with detailed usage instructions and examples for the new `gelf pr create` command.

### Testing

Manual testing was performed to validate the new feature across various scenarios:

- Successfully created a pull request using the interactive TUI.
- Canceled PR creation from the TUI prompt.
- Used `--dry-run` to preview the output, both with and without markdown rendering.
- Used the `--yes` flag to bypass the TUI and create a PR directly.
- Verified the branch push prompt when the local branch had not been pushed to the remote.
- Tested with a repository that has a `PULL_REQUEST_TEMPLATE.md` to ensure it was used as a base.
- Tested with a repository without a template to ensure the default format was used.

No new automated tests were added in this PR. Follow-up work can include adding unit and integration tests for the new components.