### PR TITLE
feat(pr): Detect and update existing pull requests

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -40,7 +40,7 @@ func init() {
 	prCreateCmd.Flags().BoolVar(&prDryRun, "dry-run", false, "Print the generated title and body without creating a pull request")
 	prCreateCmd.Flags().StringVar(&prModel, "model", "", "Override default model for PR generation")
 	prCreateCmd.Flags().StringVar(&prLanguage, "language", "", "Language for PR generation (e.g., english, japanese)")
-	prCreateCmd.Flags().BoolVar(&prRender, "render", true, "Render markdown body in dry-run output")
+	prCreateCmd.Flags().BoolVar(&prRender, "render", true, "Render pull request markdown body")
 	prCreateCmd.Flags().BoolVar(&prNoRender, "no-render", false, "Disable markdown rendering in dry-run output")
 	prCreateCmd.Flags().BoolVar(&prYes, "yes", false, "Automatically approve PR creation without confirmation")
 

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -128,7 +128,8 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 
 	if !prDryRun {
 		prContext := ui.FormatPRContext(diff, commitLog)
-		shouldContinue, err := ensureBranchPushed(cmd, headBranch, prContext)
+		var shouldContinue bool
+		shouldContinue, contextPrinted, err = ensureBranchPushed(cmd, headBranch, prContext)
 		if err != nil {
 			return err
 		}

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -144,7 +144,7 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 	if !prDryRun {
 		prContext := ui.FormatPRContext(diff, commitLog)
 		var shouldContinue bool
-		shouldContinue, contextPrinted, err = ensureBranchPushed(cmd, headBranch, prContext)
+		shouldContinue, err = ensureBranchPushed(cmd, headBranch, prContext)
 		if err != nil {
 			return err
 		}

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -1,0 +1,27 @@
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func GetRemoteURL(remoteName string) (string, error) {
+	remoteName = strings.TrimSpace(remoteName)
+	if remoteName == "" {
+		return "", fmt.Errorf("remote name is empty")
+	}
+
+	cmd := exec.Command("git", "remote", "get-url", remoteName)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get remote URL for %s: %w", remoteName, err)
+	}
+
+	remoteURL := strings.TrimSpace(string(output))
+	if remoteURL == "" {
+		return "", fmt.Errorf("remote URL for %s is empty", remoteName)
+	}
+
+	return remoteURL, nil
+}

--- a/internal/github/gh.go
+++ b/internal/github/gh.go
@@ -13,6 +13,14 @@ type RepoInfo struct {
 	Name  string
 }
 
+type PullRequestInfo struct {
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	State   string `json:"state"`
+	IsDraft bool   `json:"isDraft"`
+}
+
 func AuthToken(ctx context.Context) (string, error) {
 	cmd := exec.CommandContext(ctx, "gh", "auth", "token")
 	output, err := cmd.Output()
@@ -54,4 +62,32 @@ func RepoInfoFromGH(ctx context.Context) (*RepoInfo, error) {
 		Owner: result.Owner.Login,
 		Name:  result.Name,
 	}, nil
+}
+
+func FindOpenPullRequest(ctx context.Context, repoFullName, headRef string) (*PullRequestInfo, error) {
+	headRef = strings.TrimSpace(headRef)
+	if headRef == "" {
+		return nil, fmt.Errorf("head ref is empty")
+	}
+
+	args := []string{"pr", "list", "--state", "open", "--json", "number,title,url,state,isDraft", "--limit", "1", "--head", headRef}
+	if strings.TrimSpace(repoFullName) != "" {
+		args = append(args, "--repo", repoFullName)
+	}
+
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pull requests: %w", err)
+	}
+
+	var prs []PullRequestInfo
+	if err := json.Unmarshal(output, &prs); err != nil {
+		return nil, fmt.Errorf("failed to parse pull request list: %w", err)
+	}
+	if len(prs) == 0 {
+		return nil, nil
+	}
+
+	return &prs[0], nil
 }

--- a/internal/github/gh.go
+++ b/internal/github/gh.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"strings"
 )
@@ -19,6 +20,19 @@ type PullRequestInfo struct {
 	URL     string `json:"url"`
 	State   string `json:"state"`
 	IsDraft bool   `json:"isDraft"`
+}
+
+type pullRequestListItem struct {
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	State   string `json:"state"`
+	IsDraft bool   `json:"isDraft"`
+
+	HeadRefName         string `json:"headRefName"`
+	HeadRepositoryOwner struct {
+		Login string `json:"login"`
+	} `json:"headRepositoryOwner"`
 }
 
 func AuthToken(ctx context.Context) (string, error) {
@@ -37,57 +51,183 @@ func AuthToken(ctx context.Context) (string, error) {
 }
 
 func RepoInfoFromGH(ctx context.Context) (*RepoInfo, error) {
-	cmd := exec.CommandContext(ctx, "gh", "repo", "view", "--json", "owner,name")
+	current, parent, err := RepoInfoFromGHWithParent(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if parent != nil {
+		return parent, nil
+	}
+	return current, nil
+}
+
+func RepoInfoFromGHWithParent(ctx context.Context) (*RepoInfo, *RepoInfo, error) {
+	cmd := exec.CommandContext(ctx, "gh", "repo", "view", "--json", "owner,name,parent")
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get repository info: %w", err)
+		return nil, nil, fmt.Errorf("failed to get repository info: %w", err)
 	}
 
 	var result struct {
 		Owner struct {
 			Login string `json:"login"`
 		} `json:"owner"`
-		Name string `json:"name"`
+		Name   string `json:"name"`
+		Parent *struct {
+			Owner struct {
+				Login string `json:"login"`
+			} `json:"owner"`
+			Name string `json:"name"`
+		} `json:"parent"`
 	}
 
 	if err := json.Unmarshal(output, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse repository info: %w", err)
+		return nil, nil, fmt.Errorf("failed to parse repository info: %w", err)
 	}
 
 	if result.Owner.Login == "" || result.Name == "" {
-		return nil, fmt.Errorf("repository info is incomplete")
+		return nil, nil, fmt.Errorf("repository info is incomplete")
 	}
 
-	return &RepoInfo{
+	current := &RepoInfo{
 		Owner: result.Owner.Login,
 		Name:  result.Name,
-	}, nil
+	}
+
+	if result.Parent != nil && result.Parent.Owner.Login != "" && result.Parent.Name != "" {
+		parent := &RepoInfo{
+			Owner: result.Parent.Owner.Login,
+			Name:  result.Parent.Name,
+		}
+		return current, parent, nil
+	}
+
+	return current, nil, nil
 }
 
-func FindOpenPullRequest(ctx context.Context, repoFullName, headRef string) (*PullRequestInfo, error) {
-	headRef = strings.TrimSpace(headRef)
-	if headRef == "" {
-		return nil, fmt.Errorf("head ref is empty")
+func FindPullRequest(ctx context.Context, repoFullName, headBranch string, headOwners []string) (*PullRequestInfo, error) {
+	headBranch = strings.TrimSpace(headBranch)
+	if headBranch == "" {
+		return nil, fmt.Errorf("head branch is empty")
 	}
 
-	args := []string{"pr", "list", "--state", "open", "--json", "number,title,url,state,isDraft", "--limit", "1", "--head", headRef}
-	if strings.TrimSpace(repoFullName) != "" {
-		args = append(args, "--repo", repoFullName)
+	owners := normalizeOwners(headOwners)
+
+	listByHead := func(head string, limit int) ([]pullRequestListItem, error) {
+		args := []string{"pr", "list", "--state", "all", "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner", "--limit", fmt.Sprintf("%d", limit), "--head", head}
+		if strings.TrimSpace(repoFullName) != "" {
+			args = append(args, "--repo", repoFullName)
+		}
+
+		cmd := exec.CommandContext(ctx, "gh", args...)
+		output, err := cmd.Output()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list pull requests: %w", err)
+		}
+
+		var prs []pullRequestListItem
+		if err := json.Unmarshal(output, &prs); err != nil {
+			return nil, fmt.Errorf("failed to parse pull request list: %w", err)
+		}
+		return prs, nil
 	}
 
-	cmd := exec.CommandContext(ctx, "gh", args...)
-	output, err := cmd.Output()
+	selectMatch := func(prs []pullRequestListItem, owner string) *PullRequestInfo {
+		owner = strings.ToLower(strings.TrimSpace(owner))
+		for _, pr := range prs {
+			if strings.TrimSpace(pr.HeadRefName) != headBranch {
+				continue
+			}
+			login := strings.ToLower(strings.TrimSpace(pr.HeadRepositoryOwner.Login))
+			if owner != "" && login != owner {
+				continue
+			}
+			if owner == "" && len(owners) > 0 && login != "" {
+				if _, ok := owners[login]; !ok {
+					continue
+				}
+			}
+			return &PullRequestInfo{
+				Number:  pr.Number,
+				Title:   pr.Title,
+				URL:     pr.URL,
+				State:   pr.State,
+				IsDraft: pr.IsDraft,
+			}
+		}
+		return nil
+	}
+
+	for owner := range owners {
+		head := fmt.Sprintf("%s:%s", owner, headBranch)
+		prs, err := listByHead(head, 5)
+		if err != nil {
+			return nil, err
+		}
+		if match := selectMatch(prs, owner); match != nil {
+			return match, nil
+		}
+	}
+
+	prs, err := listByHead(headBranch, 20)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list pull requests: %w", err)
+		return nil, err
+	}
+	if match := selectMatch(prs, ""); match != nil {
+		return match, nil
 	}
 
-	var prs []PullRequestInfo
-	if err := json.Unmarshal(output, &prs); err != nil {
-		return nil, fmt.Errorf("failed to parse pull request list: %w", err)
+	return nil, nil
+}
+
+func normalizeOwners(headOwners []string) map[string]struct{} {
+	owners := make(map[string]struct{}, len(headOwners))
+	for _, owner := range headOwners {
+		owner = strings.ToLower(strings.TrimSpace(owner))
+		if owner == "" {
+			continue
+		}
+		owners[owner] = struct{}{}
 	}
-	if len(prs) == 0 {
+	return owners
+}
+
+func RepoInfoFromRemoteURL(remoteURL string) (*RepoInfo, error) {
+	remoteURL = strings.TrimSpace(remoteURL)
+	if remoteURL == "" {
 		return nil, nil
 	}
 
-	return &prs[0], nil
+	if strings.Contains(remoteURL, "://") {
+		parsed, err := url.Parse(remoteURL)
+		if err != nil {
+			return nil, nil
+		}
+		return repoInfoFromPath(parsed.Path), nil
+	}
+
+	if idx := strings.Index(remoteURL, ":"); idx != -1 {
+		return repoInfoFromPath(remoteURL[idx+1:]), nil
+	}
+
+	return nil, nil
+}
+
+func repoInfoFromPath(path string) *RepoInfo {
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, ".git")
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 {
+		return nil
+	}
+	owner := strings.TrimSpace(parts[0])
+	repo := strings.TrimSpace(parts[1])
+	if owner == "" || repo == "" {
+		return nil
+	}
+
+	return &RepoInfo{
+		Owner: owner,
+		Name:  repo,
+	}
 }


### PR DESCRIPTION
### Summary

This pull request enhances the `pr create` command by adding functionality to detect and update existing pull requests. It prevents the creation of duplicate PRs for the same branch and introduces an `--update` flag to modify an existing PR's title and body.

The detection logic is robust, supporting workflows with forked repositories by inspecting the parent repository and remote URLs.

Additionally, this PR improves the user experience by:
- Replacing the simple yes/no prompt with a more interactive one using `bubbletea`.
- Adding loading spinners for long-running operations like `git push` and `gh` commands.
- Showing the output from `git push` on failure for easier debugging.

### Changes

- **`pr create` Command Logic:**
  - Before creation, the command now checks for an existing PR for the current branch using `gh pr list`.
  - If a PR is found, it notifies the user and exits, preventing duplicates.
  - Added a new `--update` flag. When used with an existing PR, it updates the title and body using `gh pr edit`.
  - Improved detection for forked repositories by checking the parent repo and remote URLs to correctly identify the PR's head owner.

- **UI Enhancements:**
  - Replaced the standard input prompt for confirmation with an interactive `bubbletea` component.
  - Created a generalized `ui.StartSpinner` function and applied it to `git push`, `gh pr create`, and `gh pr edit` commands to provide better visual feedback.
  - The `git push` command now displays its stdout/stderr on failure.

- **Internal Refactoring:**
  - `internal/github`: Introduced `FindPullRequest` to locate PRs and `RepoInfoFromGHWithParent` to handle forked repo structures.
  - `internal/git`: Added `GetRemoteURL` to parse repository information from remote URLs.

### Testing

No automated tests were added. The new functionality was tested manually with the following scenarios:

- Creating a new PR on a branch without an existing PR.
- Attempting to create a PR on a branch that already has one (verifying it detects and exits).
- Updating an existing PR using the `--update` flag.
- Verifying all scenarios work correctly when operating from a forked repository.
- Confirming the new interactive prompt and spinners function as expected.