### PR TITLE
Improve pull request creation output formatting

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -363,14 +363,12 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 	if prNumber != "" {
 		successHeader = fmt.Sprintf("✓ Pull request created (#%s)", prNumber)
 	}
+	if prDraft {
+		successHeader = fmt.Sprintf("%s (draft)", successHeader)
+	}
 	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.RenderSuccessHeader(successHeader))
 	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.RenderSuccessMessage(prContent.Title))
-	fmt.Fprintf(cmd.OutOrStdout(), "URL: %s\n", prURL)
-	fmt.Fprintf(cmd.OutOrStdout(), "Base: %s\n", baseBranch)
-	fmt.Fprintf(cmd.OutOrStdout(), "Head: %s\n", headBranch)
-	if prDraft {
-		fmt.Fprintln(cmd.OutOrStdout(), "Draft: true")
-	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", prURL)
 
 	return nil
 }

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -388,7 +388,7 @@ func ensureBranchPushed(cmd *cobra.Command, branch string, prContext string) (bo
 	}
 
 	if strings.TrimSpace(prContext) != "" {
-		fmt.Fprintln(cmd.ErrOrStderr(), prContext)
+		fmt.Fprintf(cmd.ErrOrStderr(), "%s\n\n", prContext)
 	}
 
 	prompt := fmt.Sprintf("Current branch is not pushed to %s. Push now? (y)es / (n)o", remoteName)

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -389,7 +389,6 @@ func ensureBranchPushed(cmd *cobra.Command, branch string, prContext string) (bo
 
 	if strings.TrimSpace(prContext) != "" {
 		fmt.Fprintln(cmd.ErrOrStderr(), prContext)
-		fmt.Fprintln(cmd.ErrOrStderr())
 	}
 
 	prompt := fmt.Sprintf("Current branch is not pushed to %s. Push now? (y)es / (n)o", remoteName)
@@ -421,7 +420,7 @@ func ensureBranchPushed(cmd *cobra.Command, branch string, prContext string) (bo
 	}
 	stopSpinner()
 
-	fmt.Fprintln(cmd.OutOrStdout(), "Push succeeded.")
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n", ui.RenderSuccessHeader("✓ Push succeeded"))
 
 	return true, nil
 }

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -409,7 +409,7 @@ func ensureBranchPushed(cmd *cobra.Command, branch string, prContext string) (bo
 	var pushOutput bytes.Buffer
 	pushCmd.Stdout = &pushOutput
 	pushCmd.Stderr = &pushOutput
-	stopSpinner := ui.StartSpinner("Pushing branch...", cmd.ErrOrStderr())
+	stopSpinner := ui.StartSpinnerInline("Pushing branch...", cmd.ErrOrStderr())
 	if err := pushCmd.Run(); err != nil {
 		stopSpinner()
 		trimmed := strings.TrimSpace(pushOutput.String())
@@ -420,7 +420,7 @@ func ensureBranchPushed(cmd *cobra.Command, branch string, prContext string) (bo
 	}
 	stopSpinner()
 
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n", ui.RenderSuccessHeader("✓ Push succeeded"))
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.RenderSuccessHeader("✓ Push succeeded"))
 
 	return true, nil
 }

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -392,7 +392,7 @@ func ensureBranchPushed(cmd *cobra.Command, branch string, prContext string) (bo
 	}
 
 	prompt := fmt.Sprintf("Current branch is not pushed to %s. Push now? (y)es / (n)o", remoteName)
-	confirmed, err := ui.PromptYesNoStyled(prompt)
+	confirmed, err := ui.PromptYesNoStyledWithWriter(prompt, cmd.ErrOrStderr())
 	if err != nil {
 		return false, err
 	}

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -12,21 +12,32 @@ import (
 )
 
 func PromptYesNoStyled(prompt string) (bool, error) {
-	return PromptYesNo(promptStyle.Render(prompt))
+	return PromptYesNoStyledWithWriter(prompt, os.Stdout)
 }
 
 func PromptYesNo(prompt string) (bool, error) {
+	return PromptYesNoWithWriter(prompt, os.Stdout)
+}
+
+func PromptYesNoStyledWithWriter(prompt string, out io.Writer) (bool, error) {
+	return PromptYesNoWithWriter(promptStyle.Render(prompt), out)
+}
+
+func PromptYesNoWithWriter(prompt string, out io.Writer) (bool, error) {
+	if out == nil {
+		out = os.Stdout
+	}
 	if term.IsTerminal(int(os.Stdin.Fd())) {
 		m := &yesNoModel{prompt: prompt}
-		p := tea.NewProgram(m)
+		p := tea.NewProgram(m, tea.WithOutput(out))
 		if _, err := p.Run(); err != nil {
 			return false, err
 		}
-		fmt.Fprintln(os.Stdout)
+		fmt.Fprintln(out)
 		return m.confirmed, nil
 	}
 
-	fmt.Printf("%s ", prompt)
+	fmt.Fprintf(out, "%s ", prompt)
 
 	reader := bufio.NewReader(os.Stdin)
 	line, err := reader.ReadString('\n')

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -14,6 +14,16 @@ import (
 // StartSpinner renders a simple loading spinner on the given writer.
 // It returns a stop function that clears the line and prints a newline.
 func StartSpinner(message string, out io.Writer) func() {
+	return startSpinner(message, out, true)
+}
+
+// StartSpinnerInline renders a simple loading spinner on the given writer.
+// It returns a stop function that clears the line without printing a newline.
+func StartSpinnerInline(message string, out io.Writer) func() {
+	return startSpinner(message, out, false)
+}
+
+func startSpinner(message string, out io.Writer, newline bool) func() {
 	if out == nil {
 		out = os.Stderr
 	}
@@ -50,7 +60,11 @@ func StartSpinner(message string, out io.Writer) func() {
 	return func() {
 		close(done)
 		wg.Wait()
-		fmt.Fprint(out, "\r\033[2K\n")
+		if newline {
+			fmt.Fprint(out, "\r\033[2K\n")
+			return
+		}
+		fmt.Fprint(out, "\r\033[2K")
 	}
 }
 

--- a/internal/ui/success.go
+++ b/internal/ui/success.go
@@ -1,0 +1,11 @@
+package ui
+
+// RenderSuccessHeader applies success styling to a header line.
+func RenderSuccessHeader(text string) string {
+	return successStyle.Render(text)
+}
+
+// RenderSuccessMessage applies success styling to a message line.
+func RenderSuccessMessage(text string) string {
+	return messageStyle.Render(text)
+}


### PR DESCRIPTION
## Summary
This pull request enhances the CLI output when creating or updating pull requests. It improves the formatting of success messages by parsing the underlying `gh` command output to extract PR details, and adds support for inline spinners and custom output writers in UI prompts.

## Changes
- **cmd/pr.go**:
  - Refactored `runPRCreate` to capture and parse `gh pr create/edit` output.
  - Implemented logic to extract the PR URL and number to display stylized success messages.
  - Updated `ensureBranchPushed` to use an inline spinner and formatted success output.
- **internal/ui/prompt.go**: Added `PromptYesNoWithWriter` and `PromptYesNoStyledWithWriter` to allow specifying the output writer.
- **internal/ui/spinner.go**: Added `StartSpinnerInline` to support spinners that clean up without printing a newline.
- **internal/ui/success.go**: Created helper functions `RenderSuccessHeader` and `RenderSuccessMessage` for consistent styling.

## Testing
Tests were not run.