### PR TITLE
Update default models to Gemini 3 and location to global

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,8 @@ main.go               # アプリケーションエントリーポイント
 - **コミット対象**: ステージング済み変更のみ (`git diff --staged`)
 - **レビュー対象**: ステージング済み (`git diff --staged`) または未ステージ (`git diff`) 変更
 - **AIプロバイダー**: Vertex AI (Geminiモデル)
-- **デフォルトFlashモデル**: gemini-2.5-flash
-- **デフォルトProモデル**: gemini-2.5-pro
+- **デフォルトFlashモデル**: gemini-3-flash-preview
+- **デフォルトProモデル**: gemini-3-pro-preview
 - **モデル設定**: 設定ファイル（gelf.yml）で変更可能
 - **入力**: 生のgit diff出力 (フィルタリングなし)
 - **UIフレームワーク**: Bubble Tea (TUI用)
@@ -115,7 +115,7 @@ go run main.go review --staged   # ステージング済み変更のレビュー
 アプリケーションには以下のVertex AI設定が必要です：
 - Google Cloud プロジェクトID
 - Vertex AI API認証情報
-- モデル選択 (デフォルト: gemini-2.5-flash)
+- モデル選択 (デフォルト: gemini-3-flash-preview)
 
 ### 設定ファイル
 
@@ -129,11 +129,11 @@ go run main.go review --staged   # ステージング済み変更のレビュー
 ```yaml
 vertex_ai:
   project_id: "your-gcp-project-id"
-  location: "us-central1"
+  location: "global"
 
 model:
-  flash: "gemini-2.5-flash"  # 高速処理用モデル
-  pro: "gemini-2.5-pro"       # 高品質処理用モデル
+  flash: "gemini-3-flash-preview"  # 高速処理用モデル
+  pro: "gemini-3-pro-preview"       # 高品質処理用モデル
 ```
 
 設定の優先順位（高い順）：
@@ -151,7 +151,7 @@ devcontainerの設定：
 - `GELF_CREDENTIALS` - サービスアカウントキーへのパス（GOOGLE_APPLICATION_CREDENTIALSより優先）
 - `GOOGLE_APPLICATION_CREDENTIALS` - サービスアカウントキーへのパス
 - `VERTEXAI_PROJECT` - Google CloudプロジェクトID
-- `VERTEXAI_LOCATION` - Vertex AIのロケーション (デフォルト: us-central1)
+- `VERTEXAI_LOCATION` - Vertex AIのロケーション (デフォルト: global)
 
 モデル設定は設定ファイル（gelf.yml）でのみ変更可能です。
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Create a `gelf.yml` file in one of the following locations (in order of priority
 ```yaml
 vertex_ai:
   project_id: "your-gcp-project-id"
-  location: "us-central1"  # optional, default: us-central1
+  location: "global"  # optional, default: global
 
 model:
-  flash: gemini-2.5-flash
-  pro: gemini-2.5-pro
+  flash: gemini-3-flash-preview
+  pro: gemini-3-pro-preview
 
 language: "english"  # optional, default: english
 
@@ -97,8 +97,8 @@ export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/service-account-key.json"
 # Google Cloud project ID
 export VERTEXAI_PROJECT="your-project-id"
 
-# Vertex AI location (optional, default: us-central1)
-export VERTEXAI_LOCATION="us-central1"
+# Vertex AI location (optional, default: global)
+export VERTEXAI_LOCATION="global"
 ```
 
 **Note**: Model configuration and language settings can only be configured via configuration file, not environment variables.
@@ -340,8 +340,8 @@ This allows you to set a global default language, override it for specific comma
 - **Commit Target**: Staged changes only (`git diff --staged`)
 - **Review Target**: Both staged (`git diff --staged`) and unstaged (`git diff`) changes
 - **AI Provider**: Vertex AI (Gemini models)
-- **Default Flash Model**: gemini-2.5-flash
-- **Default Pro Model**: gemini-2.5-pro
+- **Default Flash Model**: gemini-3-flash-preview
+- **Default Pro Model**: gemini-3-pro-preview
 - **UI Framework**: Bubble Tea (TUI)
 - **CLI Framework**: Cobra
 - **Streaming**: Real-time AI response streaming for code reviews
@@ -407,11 +407,11 @@ Settings are applied in the following order (highest to lowest priority):
 ```yaml
 vertex_ai:
   project_id: string     # Google Cloud project ID
-  location: string       # Vertex AI location (default: us-central1)
+  location: string       # Vertex AI location (default: global)
 
 model:
-  flash: string          # Gemini Flash model to use (default: gemini-2.5-flash)
-  pro: string            # Gemini Pro model to use (default: gemini-2.5-pro)
+  flash: string          # Gemini Flash model to use (default: gemini-3-flash-preview)
+  pro: string            # Gemini Pro model to use (default: gemini-3-pro-preview)
 
 language: string         # Global default language (default: english)
 
@@ -441,7 +441,7 @@ color: string            # Color output setting: "always" or "never" (default: a
 | `GELF_CREDENTIALS` | Path to service account key file (gelf-specific, takes priority) | - | ⚠️* |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account key file (ADC fallback) | - | ⚠️* |
 | `VERTEXAI_PROJECT` or `GOOGLE_CLOUD_PROJECT` | Google Cloud project ID | - | ✅ |
-| `VERTEXAI_LOCATION` | Vertex AI location | `us-central1` | ❌ |
+| `VERTEXAI_LOCATION` | Vertex AI location | `global` | ❌ |
 
 *Either `GELF_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS` is required unless ADC is already available (e.g., `gcloud auth application-default login`, Workload Identity, or GCE/GKE metadata). If both are set, `GELF_CREDENTIALS` takes priority.
 

--- a/gelf.yml.example
+++ b/gelf.yml.example
@@ -9,13 +9,13 @@ vertex_ai:
   # Google Cloud Project ID for Vertex AI
   project_id: "your-gcp-project-id"
   
-  # Vertex AI region/location (default: us-central1)
-  location: "us-central1"
+  # Vertex AI region/location (default: global)
+  location: "global"
 
 # Model definitions
 model:
-  flash: gemini-2.5-flash
-  pro: gemini-2.5-pro
+  flash: gemini-3-flash-preview
+  pro: gemini-3-pro-preview
 
 # Default language for all operations (default: english)
 # Examples: english, japanese, spanish, french, german, chinese, korean

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,18 +70,18 @@ func Load() (*Config, error) {
 		location = fileConfig.VertexAI.Location
 	}
 	if location == "" {
-		location = "us-central1"
+		location = "global"
 	}
 
 	// Define model names
 	flashModel := fileConfig.Model.Flash
 	if flashModel == "" {
-		flashModel = "gemini-2.5-flash"
+		flashModel = "gemini-3-flash-preview"
 	}
 
 	proModel := fileConfig.Model.Pro
 	if proModel == "" {
-		proModel = "gemini-2.5-pro"
+		proModel = "gemini-3-pro-preview"
 	}
 
 	// Default language


### PR DESCRIPTION
## Summary

Updates the default configuration to use Gemini 3 preview models and changes the default Vertex AI location to `global`.

## Changes

- **internal/config/config.go**:
  - Updated default location from `us-central1` to `global`.
  - Updated default Flash model to `gemini-3-flash-preview`.
  - Updated default Pro model to `gemini-3-pro-preview`.
- **Documentation**: Updated `README.md` and `CLAUDE.md` to reflect the new default models and location.
- **gelf.yml.example**: Updated example configuration with the new model versions and location.

## Testing

Tests were not run.