### PR TITLE
Fix PR command output spacing and newlines

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -389,6 +389,7 @@ func ensureBranchPushed(cmd *cobra.Command, branch string, prContext string) (bo
 
 	if strings.TrimSpace(prContext) != "" {
 		fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", prContext)
+		fmt.Fprintln(cmd.ErrOrStderr())
 	}
 
 	prompt := fmt.Sprintf("Current branch is not pushed to %s. Push now? (y)es / (n)o", remoteName)

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -388,7 +388,7 @@ func ensureBranchPushed(cmd *cobra.Command, branch string, prContext string) (bo
 	}
 
 	if strings.TrimSpace(prContext) != "" {
-		fmt.Fprintf(cmd.ErrOrStderr(), "%s\n\n", prContext)
+		fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", prContext)
 	}
 
 	prompt := fmt.Sprintf("Current branch is not pushed to %s. Push now? (y)es / (n)o", remoteName)
@@ -420,7 +420,7 @@ func ensureBranchPushed(cmd *cobra.Command, branch string, prContext string) (bo
 	}
 	stopSpinner()
 
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.RenderSuccessHeader("✓ Push succeeded"))
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n", ui.RenderSuccessHeader("✓ Push succeeded"))
 
 	return true, nil
 }

--- a/internal/ui/pr.go
+++ b/internal/ui/pr.go
@@ -63,6 +63,7 @@ func (m *prModel) Run() (*ai.PullRequestContent, bool, error) {
 	}
 
 	fmt.Printf("%s\n", m.buildPRContent())
+	fmt.Println()
 
 	confirmed, err := PromptYesNoStyled(m.confirmPrompt)
 	return content, confirmed, err

--- a/internal/ui/pr.go
+++ b/internal/ui/pr.go
@@ -62,7 +62,7 @@ func (m *prModel) Run() (*ai.PullRequestContent, bool, error) {
 		}
 	}
 
-	fmt.Printf("%s\n\n", m.buildPRContent())
+	fmt.Printf("%s\n", m.buildPRContent())
 
 	confirmed, err := PromptYesNoStyled(m.confirmPrompt)
 	return content, confirmed, err


### PR DESCRIPTION
## Summary

This pull request adjusts the CLI output formatting during the PR creation process to improve readability. It standardizes newline usage when displaying context and success messages.

## Changes

- **cmd/pr.go**: Modified `ensureBranchPushed` to adjust newlines after printing the PR context and added an extra newline after the push success message.
- **internal/ui/pr.go**: Updated `Run` to explicitly print a newline after the PR content instead of embedding double newlines in the format string.

## Testing

Tests were not run.