### PR TITLE
style(pr): add trailing newline to push success message

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -420,7 +420,7 @@ func ensureBranchPushed(cmd *cobra.Command, branch string, prContext string) (bo
 	}
 	stopSpinner()
 
-	fmt.Fprintf(cmd.OutOrStdout(), "\n%s\n\n", ui.RenderSuccessHeader("✓ Push succeeded"))
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n", ui.RenderSuccessHeader("✓ Push succeeded"))
 
 	return true, nil
 }

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -420,7 +420,7 @@ func ensureBranchPushed(cmd *cobra.Command, branch string, prContext string) (bo
 	}
 	stopSpinner()
 
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.RenderSuccessHeader("✓ Push succeeded"))
+	fmt.Fprintf(cmd.OutOrStdout(), "\n%s\n\n", ui.RenderSuccessHeader("✓ Push succeeded"))
 
 	return true, nil
 }


### PR DESCRIPTION
## Summary
This pull request adjusts the output formatting of the `pr` command to include additional vertical spacing after a successful branch push.

## Changes
- Modified `cmd/pr.go` to append an extra newline character (`\n\n`) after the "Push succeeded" success header.

## Testing
Tests were not run.