### PR TITLE
Remove redundant newline after yes/no prompt

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -414,7 +414,7 @@ func ensureBranchPushed(cmd *cobra.Command, branch string) (bool, error) {
 	}
 	stopSpinner()
 
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n", ui.RenderSuccessHeader("✓ Push succeeded"))
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.RenderSuccessHeader("✓ Push succeeded"))
 
 	return true, nil
 }

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -414,7 +414,7 @@ func ensureBranchPushed(cmd *cobra.Command, branch string) (bool, error) {
 	}
 	stopSpinner()
 
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.RenderSuccessHeader("✓ Push succeeded"))
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n", ui.RenderSuccessHeader("✓ Push succeeded"))
 
 	return true, nil
 }

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -33,7 +33,6 @@ func PromptYesNoWithWriter(prompt string, out io.Writer) (bool, error) {
 		if _, err := p.Run(); err != nil {
 			return false, err
 		}
-		fmt.Fprintln(out)
 		return m.confirmed, nil
 	}
 


### PR DESCRIPTION
## Summary

This PR removes an unnecessary newline printed to the output after the interactive Yes/No prompt completes. This adjusts the CLI output spacing to be more consistent.

## Changes

- Removed `fmt.Fprintln(out)` in `internal/ui/prompt.go`.

## Testing

Tests were not run.