### PR TITLE
feat(pr): Add separate language options for title and body

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ commit:
 pr:
   model: "pro"       # optional, default: pro
   language: "english"  # optional, inherits from global language
+  title_language: "english"  # optional, inherits from pr.language
+  body_language: "english"   # optional, inherits from pr.language
 
 color: "always"  # optional, default: always
 ```
@@ -142,7 +144,9 @@ Options:
 - `--render` to render markdown in dry-run output (default: true)
 - `--no-render` to disable markdown rendering in dry-run output
 - `--model` to override the model for PR generation
-- `--language` to set the output language
+- `--language` to set the output language for both title and body
+- `--title-language` to set the language for PR title only
+- `--body-language` to set the language for PR body only
 - `--yes` to skip confirmation prompt
 
 ### Command Options
@@ -187,6 +191,9 @@ gelf pr create --dry-run --no-render
 # Use specific model and language for PR generation
 gelf pr create --model gemini-2.0-flash-exp --language japanese
 
+# Use different languages for title and body
+gelf pr create --title-language english --body-language japanese
+
 # Skip confirmation prompt
 gelf pr create --yes
 
@@ -219,6 +226,9 @@ gelf pr create --language french
 # Use different languages for different operations
 gelf commit --language english
 gelf pr create --language japanese
+
+# Use different languages for PR title and body
+gelf pr create --title-language english --body-language japanese
 ```
 
 #### 2. Configuration File
@@ -230,18 +240,23 @@ commit:
 
 pr:
   language: "english"   # Language for pull request titles and descriptions
+  title_language: "english"  # Override language for PR title only
+  body_language: "japanese"  # Override language for PR body only
 ```
 
 #### 3. Defaults
 If no language is specified, commit messages and PR content will use English.
 
 ### Priority Order
-1. Command-line `--language` flag (highest priority)
-2. Configuration file command-specific settings (`commit.language`/`pr.language`)
+1. Command-line flags (highest priority)
+   - `--language` sets both title and body language
+   - `--title-language` overrides title language specifically
+   - `--body-language` overrides body language specifically
+2. Configuration file command-specific settings (`commit.language`/`pr.language`/`pr.title_language`/`pr.body_language`)
 3. Configuration file global setting (`language`)
 4. Default value (`english`)
 
-This allows you to set a global default language, override it for specific commands, and still override everything on a per-command basis.
+This allows you to set a global default language, override it for specific commands, and even use different languages for PR titles and bodies.
 
 ## 🔧 Technical Specifications
 
@@ -318,6 +333,8 @@ commit:
 pr:
   model: string          # Model for pull requests: "flash", "pro", or custom (default: pro)
   language: string       # Language for pull request titles and descriptions (inherits from global if not set)
+  title_language: string # Language for PR title only (inherits from pr.language if not set)
+  body_language: string  # Language for PR body only (inherits from pr.language if not set)
 
 color: string            # Color output setting: "always" or "never" (default: always)
 ```

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -31,14 +31,16 @@ var prCreateCmd = &cobra.Command{
 }
 
 var (
-	prDraft    bool
-	prDryRun   bool
-	prModel    string
-	prLanguage string
-	prRender   bool
-	prNoRender bool
-	prYes      bool
-	prUpdate   bool
+	prDraft         bool
+	prDryRun        bool
+	prModel         string
+	prLanguage      string
+	prTitleLanguage string
+	prBodyLanguage  string
+	prRender        bool
+	prNoRender      bool
+	prYes           bool
+	prUpdate        bool
 )
 
 func init() {
@@ -46,6 +48,8 @@ func init() {
 	prCreateCmd.Flags().BoolVar(&prDryRun, "dry-run", false, "Print the generated title and body without creating a pull request")
 	prCreateCmd.Flags().StringVar(&prModel, "model", "", "Override default model for PR generation")
 	prCreateCmd.Flags().StringVar(&prLanguage, "language", "", "Language for PR generation (e.g., english, japanese)")
+	prCreateCmd.Flags().StringVar(&prTitleLanguage, "title-language", "", "Language for PR title (e.g., english, japanese)")
+	prCreateCmd.Flags().StringVar(&prBodyLanguage, "body-language", "", "Language for PR body (e.g., english, japanese)")
 	prCreateCmd.Flags().BoolVar(&prRender, "render", true, "Render pull request markdown body")
 	prCreateCmd.Flags().BoolVar(&prNoRender, "no-render", false, "Disable markdown rendering in dry-run output")
 	prCreateCmd.Flags().BoolVar(&prYes, "yes", false, "Automatically approve PR creation without confirmation")
@@ -62,8 +66,17 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
+	// Override language settings from command line flags
 	if prLanguage != "" {
 		cfg.PRLanguage = prLanguage
+		cfg.PRTitleLanguage = prLanguage
+		cfg.PRBodyLanguage = prLanguage
+	}
+	if prTitleLanguage != "" {
+		cfg.PRTitleLanguage = prTitleLanguage
+	}
+	if prBodyLanguage != "" {
+		cfg.PRBodyLanguage = prBodyLanguage
 	}
 
 	if prNoRender {
@@ -220,13 +233,15 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 
 	if prDryRun {
 		prContent, err := aiClient.GeneratePullRequestContent(ctx, ai.PullRequestInput{
-			BaseBranch: baseBranch,
-			HeadBranch: headBranch,
-			CommitLog:  commitLog,
-			DiffStat:   diffStat,
-			Diff:       diff,
-			Template:   templateContent,
-			Language:   cfg.PRLanguage,
+			BaseBranch:    baseBranch,
+			HeadBranch:    headBranch,
+			CommitLog:     commitLog,
+			DiffStat:      diffStat,
+			Diff:          diff,
+			Template:      templateContent,
+			Language:      cfg.PRLanguage,
+			TitleLanguage: cfg.PRTitleLanguage,
+			BodyLanguage:  cfg.PRBodyLanguage,
 		})
 		if err != nil {
 			return err
@@ -254,13 +269,15 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 	var prContent *ai.PullRequestContent
 	if prYes {
 		prContent, err = aiClient.GeneratePullRequestContent(ctx, ai.PullRequestInput{
-			BaseBranch: baseBranch,
-			HeadBranch: headBranch,
-			CommitLog:  commitLog,
-			DiffStat:   diffStat,
-			Diff:       diff,
-			Template:   templateContent,
-			Language:   cfg.PRLanguage,
+			BaseBranch:    baseBranch,
+			HeadBranch:    headBranch,
+			CommitLog:     commitLog,
+			DiffStat:      diffStat,
+			Diff:          diff,
+			Template:      templateContent,
+			Language:      cfg.PRLanguage,
+			TitleLanguage: cfg.PRTitleLanguage,
+			BodyLanguage:  cfg.PRBodyLanguage,
 		})
 		if err != nil {
 			return err
@@ -271,13 +288,15 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 			confirmPrompt = "Update this pull request? (y)es / (n)o"
 		}
 		prTUI := ui.NewPRTUI(aiClient, ai.PullRequestInput{
-			BaseBranch: baseBranch,
-			HeadBranch: headBranch,
-			CommitLog:  commitLog,
-			DiffStat:   diffStat,
-			Diff:       diff,
-			Template:   templateContent,
-			Language:   cfg.PRLanguage,
+			BaseBranch:    baseBranch,
+			HeadBranch:    headBranch,
+			CommitLog:     commitLog,
+			DiffStat:      diffStat,
+			Diff:          diff,
+			Template:      templateContent,
+			Language:      cfg.PRLanguage,
+			TitleLanguage: cfg.PRTitleLanguage,
+			BodyLanguage:  cfg.PRBodyLanguage,
 		}, prRender, cfg.UseColor(), confirmPrompt)
 
 		content, confirmed, err := prTUI.Run()

--- a/gelf.yml.example
+++ b/gelf.yml.example
@@ -39,7 +39,14 @@ pr:
   model: "pro"
 
   # Language for pull request titles and descriptions (optional, inherits from global language if not set)
+  # You can specify separate languages for title and body
   language: "english"
+
+  # Optional: Override language for PR title only (inherits from pr.language if not set)
+  # title_language: "english"
+
+  # Optional: Override language for PR body only (inherits from pr.language if not set)
+  # body_language: "japanese"
 
 # Configuration priority (highest to lowest):
 # 1. Environment variables (VERTEXAI_PROJECT, VERTEXAI_LOCATION)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.3
 require (
 	github.com/charmbracelet/bubbles v0.21.1
 	github.com/charmbracelet/bubbletea v1.3.10
-	github.com/charmbracelet/glamour v0.10.0
+	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20260202080749-832bc9d6b9d2
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/term v0.39.0

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/charmbracelet/colorprofile v0.4.1 h1:a1lO03qTrSIRaK8c3JRxJDZOvhvIeSco
 github.com/charmbracelet/colorprofile v0.4.1/go.mod h1:U1d9Dljmdf9DLegaJ0nGZNJvoXAhayhmidOdcBwAvKk=
 github.com/charmbracelet/glamour v0.10.0 h1:41/IYxsmIpaBjkMXjrjLwsHDBlucd5at6tY5n2r/qn4=
 github.com/charmbracelet/glamour v0.10.0/go.mod h1:f+uf+I/ChNmqo087elLnVdCiVgjSKWuXa/l6NU2ndYk=
+github.com/charmbracelet/glamour v1.0.0 h1:AWMLOVFHTsysl4WV8T8QgkQ0s/ZNZo7CiE4WKhk8l08=
+github.com/charmbracelet/glamour v1.0.0/go.mod h1:DSdohgOBkMr2ZQNhw4LZxSGpx3SvpeujNoXrQyH2hxo=
 github.com/charmbracelet/lipgloss v1.1.1-0.20260202080749-832bc9d6b9d2 h1:jvxZhg+J/80xXR7cE07p0/aFE1BrxkUw0R2CH04CZOM=
 github.com/charmbracelet/lipgloss v1.1.1-0.20260202080749-832bc9d6b9d2/go.mod h1:D4YudnJlpIa3bcKpFSigAEWd31pQMgYu3pFE94b/1mc=
 github.com/charmbracelet/x/ansi v0.11.6 h1:GhV21SiDz/45W9AnV2R61xZMRri5NlLnl6CVF7ihZW8=

--- a/internal/ai/vertex.go
+++ b/internal/ai/vertex.go
@@ -8,18 +8,19 @@ import (
 	"strings"
 
 	"github.com/EkeMinusYou/gelf/internal/config"
-
 	"google.golang.org/genai"
 )
 
 type PullRequestInput struct {
-	BaseBranch string
-	HeadBranch string
-	CommitLog  string
-	DiffStat   string
-	Diff       string
-	Template   string
-	Language   string
+	BaseBranch    string
+	HeadBranch    string
+	CommitLog     string
+	DiffStat      string
+	Diff          string
+	Template      string
+	Language      string
+	TitleLanguage string
+	BodyLanguage  string
 }
 
 type PullRequestContent struct {
@@ -138,6 +139,16 @@ func (v *VertexAIClient) GeneratePullRequestContent(ctx context.Context, input P
 		template = "NONE"
 	}
 
+	// Use TitleLanguage and BodyLanguage if specified, otherwise fall back to Language
+	titleLanguage := input.TitleLanguage
+	if titleLanguage == "" {
+		titleLanguage = input.Language
+	}
+	bodyLanguage := input.BodyLanguage
+	if bodyLanguage == "" {
+		bodyLanguage = input.Language
+	}
+
 	prompt := fmt.Sprintf(`You are an expert software engineer writing a GitHub pull request title and description.
 
 OUTPUT FORMAT:
@@ -146,7 +157,8 @@ OUTPUT FORMAT:
 - JSON schema: {"title":"...", "body":"..."}
 
 LANGUAGE:
-- Write in %s.
+- Write the title in %s.
+- Write the body in %s.
 
 TITLE REQUIREMENTS:
 - Concise and specific.
@@ -175,7 +187,7 @@ DIFF:
 
 PR_TEMPLATE:
 %s
-`, input.Language, input.BaseBranch, input.HeadBranch, input.CommitLog, input.DiffStat, input.Diff, template)
+`, titleLanguage, bodyLanguage, input.BaseBranch, input.HeadBranch, input.CommitLog, input.DiffStat, input.Diff, template)
 
 	resp, err := v.client.Models.GenerateContent(ctx, v.flashModel,
 		[]*genai.Content{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,17 +8,19 @@ import (
 )
 
 type Config struct {
-	ProjectID      string
-	Location       string
-	FlashModel     string
-	ProModel       string
-	BaseFlashModel string
-	BaseProModel   string
-	CommitLanguage string
-	CommitModel    string
-	PRLanguage     string
-	PRModel        string
-	Color          string
+	ProjectID       string
+	Location        string
+	FlashModel      string
+	ProModel        string
+	BaseFlashModel  string
+	BaseProModel    string
+	CommitLanguage  string
+	CommitModel     string
+	PRLanguage      string
+	PRTitleLanguage string
+	PRBodyLanguage  string
+	PRModel         string
+	Color           string
 }
 
 type FileConfig struct {
@@ -37,8 +39,10 @@ type FileConfig struct {
 		Language string `yaml:"language"`
 	} `yaml:"commit"`
 	PR struct {
-		Model    string `yaml:"model"`
-		Language string `yaml:"language"`
+		Model         string `yaml:"model"`
+		Language      string `yaml:"language"`
+		TitleLanguage string `yaml:"title_language"`
+		BodyLanguage  string `yaml:"body_language"`
 	} `yaml:"pr"`
 }
 
@@ -106,6 +110,18 @@ func Load() (*Config, error) {
 		prLanguage = defaultLanguage
 	}
 
+	// PR title language (defaults to pr.language, then global language)
+	prTitleLanguage := fileConfig.PR.TitleLanguage
+	if prTitleLanguage == "" {
+		prTitleLanguage = prLanguage
+	}
+
+	// PR body language (defaults to pr.language, then global language)
+	prBodyLanguage := fileConfig.PR.BodyLanguage
+	if prBodyLanguage == "" {
+		prBodyLanguage = prLanguage
+	}
+
 	// Color settings
 	color := fileConfig.Color
 	if color == "" {
@@ -124,17 +140,19 @@ func Load() (*Config, error) {
 	}
 
 	return &Config{
-		ProjectID:      projectID,
-		Location:       location,
-		FlashModel:     actualFlashModel,
-		ProModel:       proModel,
-		BaseFlashModel: flashModel,
-		BaseProModel:   proModel,
-		CommitLanguage: commitLanguage,
-		CommitModel:    commitModel,
-		PRLanguage:     prLanguage,
-		PRModel:        prModel,
-		Color:          color,
+		ProjectID:       projectID,
+		Location:        location,
+		FlashModel:      actualFlashModel,
+		ProModel:        proModel,
+		BaseFlashModel:  flashModel,
+		BaseProModel:    proModel,
+		CommitLanguage:  commitLanguage,
+		CommitModel:     commitModel,
+		PRLanguage:      prLanguage,
+		PRTitleLanguage: prTitleLanguage,
+		PRBodyLanguage:  prBodyLanguage,
+		PRModel:         prModel,
+		Color:           color,
 	}, nil
 }
 


### PR DESCRIPTION
### Summary

This pull request introduces the ability to specify different languages for the pull request title and body. Previously, a single `language` setting applied to both. Now, users can use the `--title-language` and `--body-language` flags, or the corresponding `pr.title_language` and `pr.body_language` configuration options for more granular control.

The existing `--language` flag is preserved as a shorthand to set both, ensuring backward compatibility.

### Changes

- **CLI (`cmd/pr.go`):**
  - Added `--title-language` and `--body-language` command-line flags.
  - Updated the `--language` flag to set both title and body languages.

- **Configuration (`internal/config/config.go`):**
  - Added `PRTitleLanguage` and `PRBodyLanguage` to the `Config` and `FileConfig` structs.
  - Implemented fallback logic: specific language (`title_language`) -> general PR language (`pr.language`) -> global language.

- **AI Prompt (`internal/ai/vertex.go`):**
  - Updated `PullRequestInput` to include separate language fields for title and body.
  - Modified the system prompt to instruct the AI to use the specified language for each part independently.

- **Documentation (`README.md`, `gelf.yml.example`):**
  - Updated the README and example config file to document the new flags, configuration options, and priority order.

- **Dependencies (`go.mod`, `go.sum`):**
  - Upgraded `github.com/charmbracelet/glamour` from `v0.10.0` to `v1.0.0`.

### Testing

No new automated tests were added. Manual verification was performed to confirm:

- The `--title-language` and `--body-language` flags correctly influence the output.
- The `title_language` and `body_language` settings in `gelf.yml` are respected.
- The fallback logic to `pr.language` and the global `language` works as expected.
- The `--language` flag correctly sets both title and body language.