### PR TITLE
Update default pro model to gemini-3.1-pro-preview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ main.go               # アプリケーションエントリーポイント
 - **PR対象**: ベースブランチとHEAD間のコミット/差分
 - **AIプロバイダー**: Vertex AI (Geminiモデル)
 - **デフォルトFlashモデル**: gemini-3-flash-preview
-- **デフォルトProモデル**: gemini-3-pro-preview
+- **デフォルトProモデル**: gemini-3.1-pro-preview
 - **モデル設定**: 設定ファイル（gelf.yml）で変更可能
 - **入力**: 生のgit diff出力 (フィルタリングなし)
 - **UIフレームワーク**: Bubble Tea (TUI用)
@@ -124,7 +124,7 @@ vertex_ai:
 
 model:
   flash: "gemini-3-flash-preview"  # 高速処理用モデル
-  pro: "gemini-3-pro-preview"       # 高品質処理用モデル
+  pro: "gemini-3.1-pro-preview"     # 高品質処理用モデル
 ```
 
 設定の優先順位（高い順）：

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ vertex_ai:
 
 model:
   flash: gemini-3-flash-preview
-  pro: gemini-3-pro-preview
+  pro: gemini-3.1-pro-preview
 
 language: "english"  # optional, default: english
 
@@ -266,7 +266,7 @@ This allows you to set a global default language, override it for specific comma
 - **PR Target**: Committed changes between base branch and `HEAD`
 - **AI Provider**: Vertex AI (Gemini models)
 - **Default Flash Model**: gemini-3-flash-preview
-- **Default Pro Model**: gemini-3-pro-preview
+- **Default Pro Model**: gemini-3.1-pro-preview
 - **UI Framework**: Bubble Tea (TUI)
 - **CLI Framework**: Cobra
 
@@ -322,7 +322,7 @@ vertex_ai:
 
 model:
   flash: string          # Gemini Flash model to use (default: gemini-3-flash-preview)
-  pro: string            # Gemini Pro model to use (default: gemini-3-pro-preview)
+  pro: string            # Gemini Pro model to use (default: gemini-3.1-pro-preview)
 
 language: string         # Global default language (default: english)
 

--- a/gelf.yml.example
+++ b/gelf.yml.example
@@ -15,7 +15,7 @@ vertex_ai:
 # Model definitions
 model:
   flash: gemini-3-flash-preview
-  pro: gemini-3-pro-preview
+  pro: gemini-3.1-pro-preview
 
 # Default language for all operations (default: english)
 # Examples: english, japanese, spanish, french, german, chinese, korean

--- a/go.sum
+++ b/go.sum
@@ -26,9 +26,7 @@ github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlv
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.4.1 h1:a1lO03qTrSIRaK8c3JRxJDZOvhvIeSco3ej+ngLk1kk=
 github.com/charmbracelet/colorprofile v0.4.1/go.mod h1:U1d9Dljmdf9DLegaJ0nGZNJvoXAhayhmidOdcBwAvKk=
-github.com/charmbracelet/glamour v0.10.0 h1:41/IYxsmIpaBjkMXjrjLwsHDBlucd5at6tY5n2r/qn4=
-github.com/charmbracelet/glamour v0.10.0/go.mod h1:f+uf+I/ChNmqo087elLnVdCiVgjSKWuXa/l6NU2ndYk=
-github.com/charmbracelet/glamour v1.0.0 h1:AWMLOVFHTsysl4WV8T8QgkQ0s/ZNZo7CiE4WKhk8l08=
+github.com/charmbracelet/glamour v1.0.0 h1:Dwe8CrZi+HX+1l3c17hFvofKyQL4RwSgXvSvkoqQK6E=
 github.com/charmbracelet/glamour v1.0.0/go.mod h1:DSdohgOBkMr2ZQNhw4LZxSGpx3SvpeujNoXrQyH2hxo=
 github.com/charmbracelet/lipgloss v1.1.1-0.20260202080749-832bc9d6b9d2 h1:jvxZhg+J/80xXR7cE07p0/aFE1BrxkUw0R2CH04CZOM=
 github.com/charmbracelet/lipgloss v1.1.1-0.20260202080749-832bc9d6b9d2/go.mod h1:D4YudnJlpIa3bcKpFSigAEWd31pQMgYu3pFE94b/1mc=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,7 +79,7 @@ func Load() (*Config, error) {
 
 	proModel := fileConfig.Model.Pro
 	if proModel == "" {
-		proModel = "gemini-3-pro-preview"
+		proModel = "gemini-3.1-pro-preview"
 	}
 
 	// Default language


### PR DESCRIPTION
### Summary
This PR updates the default Gemini Pro model used by the application from `gemini-3-pro-preview` to the newer `gemini-3.1-pro-preview`. It also includes a dependency cleanup via `go mod tidy`.

### Changes
- Update the default pro model fallback in `internal/config/config.go` to `gemini-3.1-pro-preview`.
- Update documentation references to the new default model in `README.md` and `CLAUDE.md`.
- Update the example configuration file `gelf.yml.example`.
- Clean up `go.sum` dependencies (specifically `charmbracelet/glamour`) by running `go mod tidy`.

### Testing
Tests were not run.