### PR TITLE
Add macOS quarantine removal instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ brew tap ekeminusyou/gelf
 brew install ekeminusyou/gelf/gelf
 ```
 
+If macOS blocks execution due to the quarantine attribute, remove it with:
+
+```bash
+sudo xattr -d com.apple.quarantine "$(which gelf)"
+```
+
 ## ⚙️ Setup
 
 ### 1. Configuration Options


### PR DESCRIPTION
### Summary
This PR updates the README to include instructions for resolving macOS execution blocks caused by the quarantine attribute.

### Changes
- Added a bash command to remove the `com.apple.quarantine` attribute in `README.md` for macOS users.

### Testing
Tests were not run.