### PR TITLE
fix(pr): Use existing PR's base branch when updating

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -185,6 +185,12 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to determine base branch: %w", err)
 	}
 
+	// When updating, use the existing PR's base branch to avoid including
+	// unrelated commits from a non-default base branch in the diff.
+	if updateExisting && existingPR.Base != "" {
+		baseBranch = existingPR.Base
+	}
+
 	if !prDryRun {
 		shouldContinue, err := ensureBranchPushed(cmd, headBranch)
 		if err != nil {

--- a/internal/github/gh.go
+++ b/internal/github/gh.go
@@ -20,6 +20,7 @@ type PullRequestInfo struct {
 	URL     string `json:"url"`
 	State   string `json:"state"`
 	IsDraft bool   `json:"isDraft"`
+	Base    string `json:"base"`
 }
 
 type pullRequestListItem struct {
@@ -30,6 +31,7 @@ type pullRequestListItem struct {
 	IsDraft bool   `json:"isDraft"`
 
 	HeadRefName         string `json:"headRefName"`
+	BaseRefName         string `json:"baseRefName"`
 	HeadRepositoryOwner struct {
 		Login string `json:"login"`
 	} `json:"headRepositoryOwner"`
@@ -114,7 +116,7 @@ func FindPullRequest(ctx context.Context, repoFullName, headBranch string, headO
 	owners := normalizeOwners(headOwners)
 
 	listByHead := func(head string, limit int) ([]pullRequestListItem, error) {
-		args := []string{"pr", "list", "--state", "all", "--json", "number,title,url,state,isDraft,headRefName,headRepositoryOwner", "--limit", fmt.Sprintf("%d", limit), "--head", head}
+		args := []string{"pr", "list", "--state", "all", "--json", "number,title,url,state,isDraft,headRefName,baseRefName,headRepositoryOwner", "--limit", fmt.Sprintf("%d", limit), "--head", head}
 		if strings.TrimSpace(repoFullName) != "" {
 			args = append(args, "--repo", repoFullName)
 		}
@@ -153,6 +155,7 @@ func FindPullRequest(ctx context.Context, repoFullName, headBranch string, headO
 				URL:     pr.URL,
 				State:   pr.State,
 				IsDraft: pr.IsDraft,
+				Base:    pr.BaseRefName,
 			}
 		}
 		return nil


### PR DESCRIPTION
### Summary

When updating an existing pull request that targets a non-default base branch, the tool would incorrectly use the repository's default base branch to calculate the diff. This could result in unrelated commits being included in the PR update.

This change modifies the update logic to use the existing PR's base branch, ensuring the diff is calculated correctly against the intended target branch.

### Changes

- Updated `internal/github/gh.go` to fetch the `baseRefName` when listing pull requests.
- The `PullRequestInfo` struct now includes the `Base` branch name.
- In `cmd/pr.go`, when updating an existing PR, the code now uses the PR's own base branch instead of the repository's default.

### Testing

Tests were not run.