### PR TITLE
refactor(ui): unify pull request success rendering

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -330,15 +330,11 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 			}
 			return fmt.Errorf("failed to update pull request: %w", err)
 		}
-		successHeader := "✓ Pull request updated"
+		suffix := ""
 		if existingPR.Number > 0 {
-			successHeader = fmt.Sprintf("✓ Pull request updated (#%d)", existingPR.Number)
+			suffix = fmt.Sprintf("(#%d)", existingPR.Number)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.RenderSuccessHeader(successHeader))
-		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.RenderSuccessMessage(prContent.Title))
-		if existingPR.URL != "" {
-			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", existingPR.URL)
-		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.RenderPRSuccess("✓ Pull request updated", prContent.Title, suffix, existingPR.URL))
 		return nil
 	}
 
@@ -382,16 +378,14 @@ func runPRCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	prNumber := pullNumberFromURL(prURL)
-	successHeader := "✓ Pull request created"
+	var suffixParts []string
 	if prNumber != "" {
-		successHeader = fmt.Sprintf("✓ Pull request created (#%s)", prNumber)
+		suffixParts = append(suffixParts, fmt.Sprintf("(#%s)", prNumber))
 	}
 	if prDraft {
-		successHeader = fmt.Sprintf("%s (draft)", successHeader)
+		suffixParts = append(suffixParts, "(draft)")
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.RenderSuccessHeader(successHeader))
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.RenderSuccessMessage(prContent.Title))
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", prURL)
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", ui.RenderPRSuccess("✓ Pull request created", prContent.Title, strings.Join(suffixParts, " "), prURL))
 
 	return nil
 }

--- a/internal/ui/success.go
+++ b/internal/ui/success.go
@@ -1,5 +1,10 @@
 package ui
 
+import (
+	"fmt"
+	"strings"
+)
+
 // RenderSuccessHeader applies success styling to a header line.
 func RenderSuccessHeader(text string) string {
 	return successStyle.Render(text)
@@ -8,4 +13,18 @@ func RenderSuccessHeader(text string) string {
 // RenderSuccessMessage applies success styling to a message line.
 func RenderSuccessMessage(text string) string {
 	return messageStyle.Render(text)
+}
+
+// RenderPRSuccess renders a pull request success block: the header and title
+// share the first line (styled distinctly), followed by an indented link line
+// when a URL is available.
+func RenderPRSuccess(header, title, suffix, url string) string {
+	line := fmt.Sprintf("%s %s", successStyle.Render(header+":"), messageStyle.Render(title))
+	if suffix != "" {
+		line = fmt.Sprintf("%s %s", line, subtleStyle.Render(suffix))
+	}
+	if strings.TrimSpace(url) != "" {
+		line += fmt.Sprintf("\n  🔗 %s", urlStyle.Render(url))
+	}
+	return line
 }

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -302,6 +302,13 @@ var (
 
 	deletedStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("1"))
+
+	subtleStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("8"))
+
+	urlStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("4")).
+			Underline(true)
 )
 
 func DisableColor() {
@@ -317,4 +324,6 @@ func DisableColor() {
 	fileStyle = lipgloss.NewStyle().Bold(true)
 	addedStyle = lipgloss.NewStyle()
 	deletedStyle = lipgloss.NewStyle()
+	subtleStyle = lipgloss.NewStyle()
+	urlStyle = lipgloss.NewStyle()
 }


### PR DESCRIPTION
### Summary
This PR refactors the success output rendering for pull request creation and updates. It unifies the design by introducing a dedicated rendering function that formats the success header, PR title, status suffixes (like draft or PR number), and the PR URL into a cohesive block.

### Changes
- Added `RenderPRSuccess` in `internal/ui/success.go` to format the success message with an inline header/title and an indented URL with a link icon.
- Updated `cmd/pr.go` to use `RenderPRSuccess` for both PR creation and PR update success outputs.
- Added `subtleStyle` and `urlStyle` to `internal/ui/tui.go` (and their uncolored fallbacks in `DisableColor`) to support the new rendering design.

### Testing
Tests were not run.