### PR TITLE
feat: limit staged diff size sent to AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ language: string         # Global default language (default: english)
 commit:
   model: string          # Model for commits: "flash", "pro", or custom (default: flash)
   language: string       # Language for commit messages (inherits from global if not set)
+  max_diff_bytes: number # Maximum staged diff size sent to the AI (default: 100000)
 
 pr:
   model: string          # Model for pull requests: "flash", "pro", or custom (default: pro)

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -77,6 +77,13 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	originalDiffBytes := len(diff)
+	limitedDiff, truncated := git.LimitDiff(diff, cfg.CommitMaxDiffBytes)
+	if truncated {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: staged diff is %d bytes; limiting AI input to %d bytes.\n", originalDiffBytes, cfg.CommitMaxDiffBytes)
+		diff = limitedDiff
+	}
+
 	aiClient, err := ai.NewVertexAIClient(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create AI client: %w", err)
@@ -102,9 +109,17 @@ func runCommit(cmd *cobra.Command, args []string) error {
 						fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", file.Name)
 					}
 				}
-				fmt.Fprintf(cmd.ErrOrStderr(), "\n=== Full Diff ===\n%s\n\n", diff)
+				diffHeader := "=== Full Diff ==="
+				if truncated {
+					diffHeader = "=== Diff Sent to AI (truncated) ==="
+				}
+				fmt.Fprintf(cmd.ErrOrStderr(), "\n%s\n%s\n\n", diffHeader, diff)
 			} else {
-				fmt.Fprintf(cmd.ErrOrStderr(), "=== Staged Changes ===\n%s\n\n", diff)
+				diffHeader := "=== Staged Changes ==="
+				if truncated {
+					diffHeader = "=== Staged Changes Sent to AI (truncated) ==="
+				}
+				fmt.Fprintf(cmd.ErrOrStderr(), "%s\n%s\n\n", diffHeader, diff)
 			}
 		}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -40,6 +40,7 @@ func runConfigList(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Pro Model:         %s\n", cfg.ProModel)
 	fmt.Printf("Commit Model:      %s\n", cfg.CommitModel)
 	fmt.Printf("Commit Language:   %s\n", cfg.CommitLanguage)
+	fmt.Printf("Commit Diff Limit: %d bytes\n", cfg.CommitMaxDiffBytes)
 	fmt.Printf("PR Model:          %s\n", cfg.PRModel)
 	fmt.Printf("PR Language:       %s\n", cfg.PRLanguage)
 

--- a/gelf.yml.example
+++ b/gelf.yml.example
@@ -33,6 +33,9 @@ commit:
   # Language for commit messages (optional, inherits from global language if not set)
   language: "english"
 
+  # Maximum staged diff size sent to the AI in bytes (default: 100000)
+  max_diff_bytes: 100000
+
 # PR-specific settings
 pr:
   # Model to use for pull requests: "flash", "pro", or custom model name (default: pro)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,20 +7,23 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const DefaultCommitMaxDiffBytes = 100_000
+
 type Config struct {
-	ProjectID       string
-	Location        string
-	FlashModel      string
-	ProModel        string
-	BaseFlashModel  string
-	BaseProModel    string
-	CommitLanguage  string
-	CommitModel     string
-	PRLanguage      string
-	PRTitleLanguage string
-	PRBodyLanguage  string
-	PRModel         string
-	Color           string
+	ProjectID          string
+	Location           string
+	FlashModel         string
+	ProModel           string
+	BaseFlashModel     string
+	BaseProModel       string
+	CommitLanguage     string
+	CommitModel        string
+	CommitMaxDiffBytes int
+	PRLanguage         string
+	PRTitleLanguage    string
+	PRBodyLanguage     string
+	PRModel            string
+	Color              string
 }
 
 type FileConfig struct {
@@ -35,8 +38,9 @@ type FileConfig struct {
 	Language string `yaml:"language"`
 	Color    string `yaml:"color"`
 	Commit   struct {
-		Model    string `yaml:"model"`
-		Language string `yaml:"language"`
+		Model        string `yaml:"model"`
+		Language     string `yaml:"language"`
+		MaxDiffBytes int    `yaml:"max_diff_bytes"`
 	} `yaml:"commit"`
 	PR struct {
 		Model         string `yaml:"model"`
@@ -99,6 +103,11 @@ func Load() (*Config, error) {
 		commitLanguage = defaultLanguage
 	}
 
+	commitMaxDiffBytes := fileConfig.Commit.MaxDiffBytes
+	if commitMaxDiffBytes <= 0 {
+		commitMaxDiffBytes = DefaultCommitMaxDiffBytes
+	}
+
 	// PR settings
 	prModel := fileConfig.PR.Model
 	if prModel == "" {
@@ -140,19 +149,20 @@ func Load() (*Config, error) {
 	}
 
 	return &Config{
-		ProjectID:       projectID,
-		Location:        location,
-		FlashModel:      actualFlashModel,
-		ProModel:        proModel,
-		BaseFlashModel:  flashModel,
-		BaseProModel:    proModel,
-		CommitLanguage:  commitLanguage,
-		CommitModel:     commitModel,
-		PRLanguage:      prLanguage,
-		PRTitleLanguage: prTitleLanguage,
-		PRBodyLanguage:  prBodyLanguage,
-		PRModel:         prModel,
-		Color:           color,
+		ProjectID:          projectID,
+		Location:           location,
+		FlashModel:         actualFlashModel,
+		ProModel:           proModel,
+		BaseFlashModel:     flashModel,
+		BaseProModel:       proModel,
+		CommitLanguage:     commitLanguage,
+		CommitModel:        commitModel,
+		CommitMaxDiffBytes: commitMaxDiffBytes,
+		PRLanguage:         prLanguage,
+		PRTitleLanguage:    prTitleLanguage,
+		PRBodyLanguage:     prBodyLanguage,
+		PRModel:            prModel,
+		Color:              color,
 	}, nil
 }
 

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -4,7 +4,10 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
+
+const diffTruncationMarker = "\n\n[diff truncated]"
 
 func GetStagedDiff() (string, error) {
 	cmd := exec.Command("git", "--no-pager", "diff", "--staged", "-U5")
@@ -24,6 +27,38 @@ func GetUnstagedDiff() (string, error) {
 	}
 
 	return strings.TrimSpace(string(output)), nil
+}
+
+// LimitDiff returns a diff that fits within maxBytes and reports whether it was truncated.
+func LimitDiff(diff string, maxBytes int) (string, bool) {
+	if maxBytes <= 0 || len(diff) <= maxBytes {
+		return diff, false
+	}
+
+	if maxBytes <= len(diffTruncationMarker) {
+		return validUTF8Prefix(diff, maxBytes), true
+	}
+
+	prefixLimit := maxBytes - len(diffTruncationMarker)
+	prefix := diff[:prefixLimit]
+	if newline := strings.LastIndexByte(prefix, '\n'); newline > 0 {
+		prefix = prefix[:newline]
+	}
+	prefix = validUTF8Prefix(prefix, len(prefix))
+
+	return prefix + diffTruncationMarker, true
+}
+
+func validUTF8Prefix(value string, maxBytes int) string {
+	if len(value) > maxBytes {
+		value = value[:maxBytes]
+	}
+
+	for len(value) > 0 && !utf8.ValidString(value) {
+		value = value[:len(value)-1]
+	}
+
+	return value
 }
 
 func CommitChanges(message string) error {

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -1,0 +1,70 @@
+package git
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestLimitDiff(t *testing.T) {
+	const diffTruncationMarkerLength = len(diffTruncationMarker)
+
+	tests := []struct {
+		name      string
+		diff      string
+		maxBytes  int
+		truncated bool
+	}{
+		{
+			name:      "keeps diff below limit",
+			diff:      "diff --git a/file b/file",
+			maxBytes:  100,
+			truncated: false,
+		},
+		{
+			name:      "does not truncate when limit is disabled",
+			diff:      "large diff",
+			maxBytes:  0,
+			truncated: false,
+		},
+		{
+			name:      "truncates at a line boundary",
+			diff:      "diff --git a/file b/file\n" + strings.Repeat("+line\n", 20),
+			maxBytes:  len("diff --git a/file b/file\n"+strings.Repeat("+line\n", 2)) + diffTruncationMarkerLength,
+			truncated: true,
+		},
+		{
+			name:      "does not split UTF-8 characters",
+			diff:      strings.Repeat("日本語", 20),
+			maxBytes:  40,
+			truncated: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			limited, truncated := LimitDiff(test.diff, test.maxBytes)
+
+			if truncated != test.truncated {
+				t.Fatalf("truncated = %v, want %v", truncated, test.truncated)
+			}
+			if !truncated && limited != test.diff {
+				t.Fatalf("diff changed without truncation: %q", limited)
+			}
+			if test.truncated && len(limited) > test.maxBytes {
+				t.Fatalf("limited diff is %d bytes, want at most %d", len(limited), test.maxBytes)
+			}
+			if test.truncated && !utf8.ValidString(limited) {
+				t.Fatal("limited diff is not valid UTF-8")
+			}
+			if test.name == "truncates at a line boundary" {
+				if !strings.HasSuffix(limited, diffTruncationMarker) {
+					t.Fatalf("limited diff does not have truncation marker: %q", limited)
+				}
+				if strings.Contains(limited, "+line\n+line\n+line\n") {
+					t.Fatalf("limited diff contains a line beyond the limit: %q", limited)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
AIによるコミットメッセージ生成時に送信されるステージング済みの差分（diff）サイズを制限する機能を追加しました。これにより、巨大な変更を行った際にAIのトークン制限やペイロードサイズの上限を超過する問題を防ぎます。

## Changes
- `gelf.yml` および設定構造体に `commit.max_diff_bytes` を追加（デフォルト: 100,000バイト）。
- `internal/git/diff.go` に `LimitDiff` 関数を追加。指定されたバイト数でdiffを安全に切り詰め（UTF-8境界と改行位置を考慮）、末尾に `[diff truncated]` マーカーを付与する処理を実装。
- `cmd/commit.go` を更新し、diffが切り詰められた場合に標準エラー出力へ警告を表示し、出力ヘッダーを変更するよう修正。
- `cmd/config.go` の設定一覧表示に `Commit Diff Limit` の項目を追加。

## Testing
- `internal/git/diff_test.go` にて `LimitDiff` 関数のユニットテストを追加（制限値内の動作、無効化時の動作、改行境界での切り詰め、UTF-8文字の境界保持を検証）。
- 実際の環境での動作確認（手動テスト）が実行されたかは不明なため、テストは実行されていません。